### PR TITLE
Check for `is_dir()` instead of `file_exists()`.

### DIFF
--- a/includes/Classes/Elements_Manager.php
+++ b/includes/Classes/Elements_Manager.php
@@ -247,7 +247,7 @@ class Elements_Manager {
 	 */
 	public function generate_script( $post_id, $elements, $context, $ext ) {
 		// if folder not exists, create new folder
-		if ( ! file_exists( EAEL_ASSET_PATH ) ) {
+		if ( ! is_dir( EAEL_ASSET_PATH ) ) {
 			wp_mkdir_p( EAEL_ASSET_PATH );
 		}
 


### PR DESCRIPTION
On some hosts with stream wrappers `file_exists()` will always return true for directories even if it's not present.