### PR TITLE
Add attributes to allowed list for wp_kses helper function

### DIFF
--- a/includes/Classes/Helper.php
+++ b/includes/Classes/Helper.php
@@ -1257,6 +1257,8 @@ class Helper
 	            'id'    => [],
 	            'style' => [],
                 'align' => [],
+	  	'colspan' => [],
+		'rowspan' => [],
             ],
             'tr' => [
 	            'class' => [],
@@ -1269,6 +1271,8 @@ class Helper
 	            'id'    => [],
 	            'style' => [],
                 'align' => [],
+		'colspan' => [],
+		'rowspan' => [],    
             ],
         ];
     }


### PR DESCRIPTION
Added colspan and rowspan attributes to the list of allowed attributes for the wp_kses helper function to allow for merged cells from a google sheet to function properly