### PR TITLE
Fix start date vs hide old events

### DIFF
--- a/includes/Elements/Event_Calendar.php
+++ b/includes/Elements/Event_Calendar.php
@@ -3225,9 +3225,9 @@ class Event_Calendar extends Widget_Base
                 }
 
 	            $default_date = $settings['eael_event_default_date_type'] === 'custom' ? $settings['eael_event_calendar_default_date'] : date( 'Y-m-d' );
-	            $should_show  = $this->is_old_event( $start, $default_date );
+	            $should_hide  = $this->is_old_event( $start, $default_date );
 
-	            if ( $should_show ) {
+	            if ( $should_hide ) {
 		            continue;
 	            }
 
@@ -3356,9 +3356,9 @@ class Event_Calendar extends Widget_Base
                 }
 
 	            $default_date = $settings['eael_event_default_date_type'] === 'custom' ? $settings['eael_event_calendar_default_date'] : date( 'Y-m-d' );
-	            $should_show  = $this->is_old_event( $ev_start_date, $default_date );
+	            $should_hide  = $this->is_old_event( $ev_start_date, $default_date );
 
-	            if ( $should_show ) {
+	            if ( $should_hide ) {
 		            continue;
 	            }
 

--- a/includes/Elements/Event_Calendar.php
+++ b/includes/Elements/Event_Calendar.php
@@ -3202,6 +3202,13 @@ class Event_Calendar extends Widget_Base
                     if($is_old_event) {
                         continue;
                     }
+
+                    $default_date = $settings['eael_event_default_date_type'] === 'custom' ? $settings['eael_event_calendar_default_date'] : date( 'Y-m-d' );
+                    $should_hide  = $this->is_old_event( $start, $default_date );
+
+                    if ( $should_hide ) {
+                        continue;
+                    }
                 }
 
                 $settings_eael_event_global_bg_color = $this->fetch_color_or_global_color($event, 'eael_event_bg_color');
@@ -3223,13 +3230,6 @@ class Event_Calendar extends Widget_Base
                         }
                     }
                 }
-
-	            $default_date = $settings['eael_event_default_date_type'] === 'custom' ? $settings['eael_event_calendar_default_date'] : date( 'Y-m-d' );
-	            $should_hide  = $this->is_old_event( $start, $default_date );
-
-	            if ( $should_hide ) {
-		            continue;
-	            }
 
 	            $data[] = [
 		            'id'                => $i,
@@ -3353,14 +3353,14 @@ class Event_Calendar extends Widget_Base
                     if($is_old_event) {
                         continue;
                     }
+
+                    $default_date = $settings['eael_event_default_date_type'] === 'custom' ? $settings['eael_event_calendar_default_date'] : date( 'Y-m-d' );
+                    $should_hide  = $this->is_old_event( $ev_start_date, $default_date );
+
+                    if ( $should_hide ) {
+                        continue;
+                    }
                 }
-
-	            $default_date = $settings['eael_event_default_date_type'] === 'custom' ? $settings['eael_event_calendar_default_date'] : date( 'Y-m-d' );
-	            $should_hide  = $this->is_old_event( $ev_start_date, $default_date );
-
-	            if ( $should_hide ) {
-		            continue;
-	            }
 
                 $calendar_data[] = [
                     'id' => ++$key,


### PR DESCRIPTION
Fix a bug where past events are hidden even if config says to show them

This May 2022 commit allows users to configure whether past events
should be shown or hidden:

https://github.com/WPDevelopers/essential-addons-for-elementor-lite/commit/0fdca9b57da5e67ac0d6d5214ab1686b3604102b

This August 2023 commit fixes some issue with the default start date. I
don’t know what the relevant issue was. However, the commit introduces a
new bug, where events from before the configured "start date" are
hidden, irrespective of what the user configuration says about past
events.

https://github.com/WPDevelopers/essential-addons-for-elementor-lite/commit/0bb68c4eed3a6ddb5a4934a854152eacad4c8232