### PR TITLE
Event Calendar list view: make row color and event background consistent

### DIFF
--- a/includes/Elements/Event_Calendar.php
+++ b/includes/Elements/Event_Calendar.php
@@ -2559,7 +2559,7 @@ class Event_Calendar extends Widget_Base
                 'type' => Controls_Manager::COLOR,
                 'default' => '#ffffff',
                 'selectors' => [
-                    '{{WRAPPER}} .eael-event-calendar-wrapper .fc-list-event:nth-child(even)' => 'background-color: {{VALUE}} !important;',
+                    '{{WRAPPER}} .eael-event-calendar-wrapper .fc-list-event:nth-child(even) td' => 'background-color: {{VALUE}} !important;',
                 ],
             ]
         );


### PR DESCRIPTION
In the Event Calendar widget, if we configure an odd row color and an even row color, then that color takes precedence over the indiviudal events’ background color; but only for odd rows. This commit makes that also the case for even rows.