### PR TITLE
fix duplicate tax_query arg

### DIFF
--- a/includes/Classes/Helper.php
+++ b/includes/Classes/Helper.php
@@ -738,12 +738,8 @@ class Helper
                 ];
             }
 
-            if ( isset($data->taxonomy) ) {
-                $args[ 'tax_query' ][] = [
-                    'taxonomy' => $data->taxonomy,
-                    'field'    => 'term_id',
-                    'terms'    => $data->term_id,
-                ];
+            if ( isset($wp_query->tax_query) ) {
+                $args[ 'tax_query' ][] = $wp_query->tax_query->queries;
             }
 
             if (get_query_var('author') > 0) {


### PR DESCRIPTION
Hi,

in the get_dynamic_args function there are two identical checks for $data->taxonomy. Furthermore, the filter for tax already defined in wp_query is never taken into consideration.

R.