### PR TITLE
Fix Gravity Forms Ajax enabled submissions aborting when show title or description enabled

### DIFF
--- a/includes/Elements/GravityForms.php
+++ b/includes/Elements/GravityForms.php
@@ -2914,9 +2914,9 @@ class GravityForms extends Widget_Base {
                 <?php } ?>
                 <?php
                     $eael_form_id = $settings['contact_form_list'];
-                    $eael_form_title = $settings['form_title'];
-                    $eael_form_description = $settings['form_description'];
-                    $eael_form_ajax = $settings['form_ajax'];
+                    $eael_form_title = boolval( $settings['form_title'] );
+                    $eael_form_description = boolval( $settings['form_description'] );
+                    $eael_form_ajax = boolval( $settings['form_ajax'] );
 
                     gravity_form( $eael_form_id, $eael_form_title, $eael_form_description, $display_inactive = false, $field_values = null, $eael_form_ajax, '', $echo = true );
                 ?>


### PR DESCRIPTION
With Gravity Forms 2.9.2, when the show title or show description toggles are enabled, along with the use Ajax toggle in the widget settings, submissions are aborting and display the default confirmation text used by new forms. The submissions are failing the new hash validation for the `gform_ajax` input, which contains the embed settings.

This resolves that issue by converting the string-based values of those toggles (e.g. `yes`) to the expected booleans before they are passed to `gravity_form()`.

Gravity Forms support currently has 7 tickets about this issue.