### PR TITLE
Fix: CSV source of Advanced Data Table handles UTF-8 incorrectly.

### DIFF
--- a/includes/Elements/Advanced_Data_Table.php
+++ b/includes/Elements/Advanced_Data_Table.php
@@ -1564,7 +1564,7 @@ class Advanced_Data_Table extends Widget_Base
 
             if ( $content && 'csv' === $settings['ea_adv_data_table_source'] ) {
                 $dom = new \DOMDocument();
-                @$dom->loadHTML("<table>$content</table>");
+                @$dom->loadHTML("<?xml encoding='UTF-8'><table>$content</table>");
                 $rows = $dom->getElementsByTagName('tr');
                 $content = '';
                 $pagination = ! empty( $settings['ea_adv_data_table_items_per_page'] ) ? $settings['ea_adv_data_table_items_per_page'] : 10;


### PR DESCRIPTION
Hello,

pasting UTF-8 encoded CSV string into Advanced Data Table CSV input field results in broken encoding in Elementor preview area. This is happening because DOMDocument->loadHTML() doesn't care about UTF-8. We need to add XML header with explicit UTF-8 encoding set to loadHTML() source string.

Attaching example CSV file with UTF-8 encoding you can test the bug with:
[utf8.csv](https://github.com/user-attachments/files/19111914/utf8.csv)
