### PR TITLE
Add Live Preview support to Essential Addons for Elementor

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,48 @@
+{
+  "landingPage": "/wp-admin/admin.php?page=eael-settings",
+  "preferredVersions": {
+    "wp": "latest",
+    "php": "latest"
+  },
+  "steps": [
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "elementor"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "installTheme",
+      "themeData": {
+        "resource": "wordpress.org/themes",
+        "slug": "hello-biz"
+      },
+      "options": {
+        "activate": true
+      },
+      "progress": {
+        "caption": "Installing theme: hello-biz"
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "essential-addons-for-elementor-lite"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "setSiteOptions",
+      "options": {
+        "elementor_onboarded": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Essential Addons for Elementor currently doesn't support [Live Previews](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/) on its [WordPress.org plugin page](https://wordpress.org/plugins/essential-addons-for-elementor-lite/).

This PR adds a Blueprint for Essential Addons to enable Live Previews on WordPress.org.

The Blueprint installs Essential Addons for Elementor and Elementor, together with the Hello Biz theme. It disables Elementor onboarding and Essential Addons general settings page.

Note: Alongside adding a blueprint.json to SVN, live previews need to be [enabled in the plugin’s Advanced view.
](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/#enabling-plugin-previews)

## Testing instructions

- Open this [Playground link](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fbgrgicak%2Fessential-addons-for-elementor-lite%2F08b988d440f0544ce4224fe041b9af3563b2176e%2F.wordpress-org%2Fblueprints%2Fblueprint.json) to see the Blueprint

## Screenshot

<img width="1428" height="1183" alt="Screenshot 2025-11-18 at 11 52 19" src="https://github.com/user-attachments/assets/23c22c9c-30f0-4bad-b883-5c43e5e51bd7" />

