### PR TITLE
fix(woo-product-grid): bump default image size from medium to large [#81331]

### DIFF
--- a/includes/Elements/Product_Grid.php
+++ b/includes/Elements/Product_Grid.php
@@ -974,7 +974,7 @@ class Product_Grid extends Widget_Base
             [
                 'name' => 'eael_product_grid_image_size',
                 'exclude' => ['custom'],
-                'default' => 'medium',
+                'default' => 'large',
                 'label_block' => true,
             ]
         );


### PR DESCRIPTION
## Summary

- Card: [FluentBoards #81331 — Feature Improvement | EA Woo Product Grid | Option to set image resolution](https://projects.startise.com//fbs-81331)
- Reporter (Rashed Amin): Woo Product Grid images "forced to 600×400, need full image high-res". Refs: https://d.pr/v/DLFFOH, https://wordpress.org/support/topic/image-size-274/

## Root cause

The image-size control **already exists** and is wired into every preset render path. There is nothing missing:

- Control: `includes/Elements/Product_Grid.php:972-980` (`Group_Control_Image_Size`, control name `eael_product_grid_image_size`)
- Render: every preset under `includes/Template/Eicon-Woocommerce/*.php` reads `$settings['eael_product_grid_image_size_size']` and passes it to `$product->get_image(...)` — verified across all 16 templates (`simple.php:87`, `reveal.php:86`, `overlay.php:85`, `preset-1..8.php`, `list-preset-1..4.php`).

What the reporter saw is the **default value `'medium'` resolving to 600×400** on WP/Woo installs where `'medium'` is mapped to `woocommerce_thumbnail` (the Woo-default 600×400). The control was visible — it just defaulted to a small size.

## Change

Single-line: `'default' => 'medium'` → `'default' => 'large'` at `Product_Grid.php:977`. `large` caps at 1024px on default WP, so a fresh widget no longer lands on the small Woo thumbnail.

## Caveats

- **Affects newly inserted widgets only.** Elementor freezes a control's default at insertion time, so existing pages keep whatever value is currently stored. Existing reporter pages still need a manual re-pick (or a per-page override).
- **Visual verification not run** in this PR — change is single-string, render path is unchanged, regression risk is minimal. Reviewer should still spot-check one preset in the editor + front-end before merge.
- **Widget doc deferred.** A `docs/widgets/product-grid.md` update was planned but the widget-docs corpus + `_template.md` live on unmerged branch `80746` — adding the doc here would mix scopes. Will land as a follow-up after `80746` merges.

## Test plan

- [ ] Pull this branch on a WP/Woo test site, drop a fresh Product Grid widget, confirm Image Size group control defaults to **Large**.
- [ ] Switch through Thumbnail / Medium / Large / Full and confirm the rendered `<img src>` / `srcset` actually changes resolution.
- [ ] Spot-check at least one of: `simple`, `reveal`, `preset-1`, `list-preset-1`.
- [ ] Confirm existing pages with the widget render unchanged (default change must not retroactively rewrite stored values).