### PR TITLE
Fix Event Calendar end time timezone offset

### DIFF
--- a/includes/Elements/Event_Calendar.php
+++ b/includes/Elements/Event_Calendar.php
@@ -4146,17 +4146,18 @@ class Event_Calendar extends Widget_Base
         $events = $settings['eael_event_items'];
         $data = [];
         if ($events) {
+            $utc_timezone = new \DateTimeZone( 'UTC' );
             $i = 0;
             foreach ($events as $event) {
 
                 if ($event['eael_event_all_day'] == 'yes') {
                     $start = !empty( $event["eael_event_start_date_allday"] ) ? $event["eael_event_start_date_allday"] : wp_date('Y-m-d', current_time('timestamp', 0));
 					$_end  = !empty( $event["eael_event_end_date_allday"] ) ? $event["eael_event_end_date_allday"] : wp_date('Y-m-d', current_time('timestamp', 0));
-                    $end = wp_date('Y-m-d', strtotime("+1 days", strtotime($_end)));
+                    $end = wp_date('Y-m-d', strtotime("+1 days", strtotime($_end)), $utc_timezone);
                 } else {
                     $start = !empty( $event["eael_event_start_date"] ) ? $event["eael_event_start_date"] : wp_date('Y-m-d', current_time('timestamp', 0));
 					$_end  = !empty( $event["eael_event_end_date"] ) ? $event["eael_event_end_date"] : wp_date('Y-m-d', strtotime("+59 minute", current_time('timestamp', 0)) );
-                    $end = wp_date('Y-m-d H:i', strtotime($_end))  . ":01";
+                    $end = wp_date('Y-m-d H:i', strtotime($_end), $utc_timezone)  . ":01";
                 }
 
                 if( !empty( $settings["eael_old_events_hide"] ) && 'yes' === $settings["eael_old_events_hide"] ){
@@ -4400,6 +4401,7 @@ class Event_Calendar extends Widget_Base
         $random_color_index = 0;
 
         $calendar_data = [];
+        $utc_timezone = new \DateTimeZone( 'UTC' );
         foreach ($events as $key => $event) {
             $date_format = 'Y-m-d';
             $all_day = 'yes';
@@ -4410,9 +4412,9 @@ class Event_Calendar extends Widget_Base
 
 
             if (tribe_event_is_all_day($event->ID)) {
-              $end = wp_date('Y-m-d', strtotime("+1 days", strtotime(tribe_get_end_date($event->ID, true, $date_format))));
+              $end = wp_date('Y-m-d', strtotime("+1 days", strtotime(tribe_get_end_date($event->ID, true, $date_format))), $utc_timezone);
             } else {
-              $end = wp_date('Y-m-d H:i', strtotime(tribe_get_end_date($event->ID, true, $date_format))) . ":01";
+              $end = wp_date('Y-m-d H:i', strtotime(tribe_get_end_date($event->ID, true, $date_format)), $utc_timezone) . ":01";
             }
             
             if ( $random_color_enabled ) {

--- a/tests/e2e/specs/event-calendar-timezone.spec.ts
+++ b/tests/e2e/specs/event-calendar-timezone.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Event Calendar Widget", () => {
+	test("keeps manual event end times in the site timezone", async ({ page }) => {
+		await page.goto("/event-calendar-timezone-test/");
+
+		const calendar = page.locator(".eael-event-calendar-cls");
+		await expect(calendar).toBeVisible();
+
+		const eventTime = page.locator(".fc-list-event-time").first();
+		await expect(eventTime).toHaveText("11:00 - 14:00");
+		await expect(eventTime).not.toContainText("16:00");
+	});
+});

--- a/tests/e2e/templates/event-calendar-timezone.json
+++ b/tests/e2e/templates/event-calendar-timezone.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "eaec001",
+    "elType": "section",
+    "settings": [],
+    "elements": [
+      {
+        "id": "eaec002",
+        "elType": "column",
+        "settings": { "_column_size": 100 },
+        "elements": [
+          {
+            "id": "eaec003",
+            "elType": "widget",
+            "widgetType": "eael-event-calendar",
+            "settings": {
+              "eael_event_calendar_type": "manual",
+              "eael_event_display_layout": "calendar",
+              "eael_event_calendar_default_view": "listMonth",
+              "eael_event_default_date_type": "custom",
+              "eael_event_calendar_default_date": "2026-06-21",
+              "eael_event_time_format": "yes",
+              "eael_event_details_link_hide": "yes",
+              "eael_event_items": [
+                {
+                  "_id": "event1",
+                  "eael_event_title": "Berlin Summer Event",
+                  "eael_event_link": {
+                    "url": "",
+                    "is_external": "",
+                    "nofollow": "",
+                    "custom_attributes": ""
+                  },
+                  "eael_event_redirection": "",
+                  "eael_event_all_day": "",
+                  "eael_event_start_date": "2026-06-21 11:00",
+                  "eael_event_end_date": "2026-06-21 14:00",
+                  "eael_event_description": "Regression coverage for local event times.",
+                  "eael_event_bg_color": "#1d4ed8",
+                  "eael_event_text_color": "#ffffff",
+                  "eael_event_border_color": "#1d4ed8",
+                  "eael_event_location": "Berlin",
+                  "eael_event_category": "Regression"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/e2e/utils/seed.sh
+++ b/tests/e2e/utils/seed.sh
@@ -12,6 +12,7 @@ EAEL_SLUG=$(wp plugin list --field=name --allow-root | grep essential-addons | h
 echo "==> Setting permalink structure..."
 wp rewrite structure '/%postname%/' --allow-root
 wp rewrite flush --allow-root
+wp option update timezone_string Europe/Berlin --allow-root
 
 # Create an Elementor page from a JSON template.
 # Usage: create_elementor_page "Title" "slug" "template.json"
@@ -39,9 +40,10 @@ create_elementor_page() {
 
 echo "==> Creating test pages..."
 create_elementor_page "Info Box Test" "info-box-test" "info-box.json"
+create_elementor_page "Event Calendar Timezone Test" "event-calendar-timezone-test" "event-calendar-timezone.json"
 
 echo "==> Flushing Elementor CSS..."
 wp elementor flush-css --allow-root 2>/dev/null || true
 
 echo "==> Done. http://localhost:8888 | wp-admin: admin / password"
-echo "    Pages: /info-box-test/"
+echo "    Pages: /info-box-test/, /event-calendar-timezone-test/"


### PR DESCRIPTION
## Summary

While checking the Event Calendar widget after the 6.6.6 release, I noticed that manually configured event times were no longer displayed consistently.

In the Elementor event settings, the event was configured as:

- Start: `11:00`
- End: `14:00`
- Site timezone: `Europe/Berlin`

But on the frontend, the same event was displayed as:

- `11:00 - 16:00`

The start time stayed correct, but the end time was shifted by the current site timezone offset.

## Cause

In 6.6.6, Event Calendar date formatting was migrated from `gmdate()` to `wp_date()` for timezone consistency.

That worked for most date output, but manual event end dates are already stored as local Elementor date/time strings. Passing those values through `wp_date()` without an explicit timezone caused WordPress to apply the site timezone offset again when formatting the end time.

This affected the event end time only because the start time is passed through unchanged, while the end time is reformatted before being sent to FullCalendar.

## Fix

The affected end-time formatting now still uses `wp_date()`, but with an explicit UTC timezone.

This keeps the code consistent with the 6.6.6 `wp_date()` migration while preserving the previous behavior for already-local event end date strings.

The same adjustment was applied to:

- Manual Event Calendar events
- The Events Calendar integration end-time formatting

## Testing

Tested with `Europe/Berlin` timezone:

- Summer time event: `11:00 - 14:00` stays `11:00 - 14:00`
- Standard time event: `11:00 - 14:00` stays `11:00 - 14:00`
- Verified the 6.6.6 timed-event filtering fix still works:
  - past timed events are filtered
  - future timed events remain visible
  - current-day all-day events remain visible

Automated test coverage:

- Added an E2E regression test for the frontend Event Calendar output.
- `npm run test:e2e` passes.