### PR TITLE
Fix: Filterable Gallery emits invalid markup — play icon class + unbalanced </a>

### DIFF
--- a/includes/Elements/Filterable_Gallery.php
+++ b/includes/Elements/Filterable_Gallery.php
@@ -3953,7 +3953,7 @@ class Filterable_Gallery extends Widget_Base
         }
 
         if (!empty($icon_url)) {
-            $html .= '<img width="62" height="62" src="' . esc_url($icon_url) . '" alt="eael-fg-video-play-icon" >';
+            $html .= '<img width="62" height="62" src="' . esc_url($icon_url) . '" class="eael-fg-video-play-icon" alt="" >';
         }
 
         $html .= '</a>';
@@ -4259,7 +4259,10 @@ class Filterable_Gallery extends Widget_Base
                 }
             }
 
-            if ($settings['eael_fg_show_popup'] == 'media') {
+            // Mirror the opening condition (~line 4251) so the anchor is only closed
+            // when it was actually opened. Card-layout video items open no media
+            // anchor here, so an unconditional close emitted an orphan </a>.
+            if ($settings['eael_fg_show_popup'] == 'media' && $settings['eael_fg_caption_style'] !== 'card' && !$this->popup_status) {
                 $html .= '</a>';
             }
 


### PR DESCRIPTION
## Executive Summary
Two DOM-correctness defects in the video render path: (1) the play-icon identifier `eael-fg-video-play-icon` is emitted as the image's `alt` instead of a CSS class, so author/plugin styles targeting it silently no-op; (2) card-layout video items emit an **orphan `</a>`** because the closing tag at line 4262 is not gated by the same condition as its opening tags. No behavioral change to lightbox/filtering.

## Problem Statement
1. **Play icon:** `Filterable_Gallery.php:3956` sets `alt="eael-fg-video-play-icon"`. No element carries that as a class anywhere in the plugin (grep across `includes/` + `src/`), so `.eael-fg-video-play-icon` matches nothing.
2. **Orphan anchor:** For Card + video + `show_popup = media`, both opening `<a>` emitters are suppressed (`:4226` requires `video_gallery_switch != 'true'`; `:4252` requires `caption_style !== 'card'`), but the close at `:4262` fires on `show_popup == 'media'` regardless → `…</a></div></a><div class="gallery-item-caption-wrap…`. Verified against the live DOM.

## Root Cause
The closing-anchor condition at `:4262` does not mirror the opening condition at `:4252` (one predicate vs three). The play-icon issue is a literal attribute mistake (`alt` used as a styling hook).

## Technical Solution
1. Emit `eael-fg-video-play-icon` as a **class**; set `alt=""` (decorative; anchor already has `aria-label` + `title`).
2. Make the close condition at `:4262` identical to the open at `:4252`. Between the two points none of the three operands change (only the hoverer caption is appended), so recomputing the expression is provably symmetric — no new state variable.

## Detailed File Changes
**`includes/Elements/Filterable_Gallery.php` ~3956** — play icon as class:
```diff
-            $html .= '<img width="62" height="62" src="' . esc_url($icon_url) . '" alt="eael-fg-video-play-icon" >';
+            $html .= '<img width="62" height="62" src="' . esc_url($icon_url) . '" class="eael-fg-video-play-icon" alt="" >';
```
**`includes/Elements/Filterable_Gallery.php` ~4262** — gate close to mirror open:
```diff
-            if ($settings['eael_fg_show_popup'] == 'media') {
+            if ($settings['eael_fg_show_popup'] == 'media' && $settings['eael_fg_caption_style'] !== 'card' && !$this->popup_status) {
                 $html .= '</a>';
             }
```

## QA Checklist
Desktop (validate generated DOM): [ ] Chrome [ ] Firefox [ ] Safari [ ] Edge — card video item: exactly one `<a class="video-popup …">…</a>`, no stray `</a>`; play icon `<img class="eael-fg-video-play-icon" alt="">`.
Mobile (markup-only, behavior unchanged): [ ] Android Chrome [ ] Samsung Internet [ ] iOS Safari.
Mode × content DOM-validity matrix: [ ] Card+media+video (fixed) [ ] Card+media+image [ ] hoverer+media+video [ ] hoverer+media+image [ ] show_popup=buttons + Card+video [ ] full-image-clickable ON + Card+video.

## Regression Checklist
[ ] W3C Nu validator before/after — anchor-balance warning gone. [ ] Lightbox opens for image + video in all combos. [ ] Filtering + Load More re-render valid markup. [ ] No PHP notices (`$this->popup_status` initialized in render loop).

## Accessibility Review
Improvement: decorative icon now `alt=""` (was a meaningless identifier string announced by AT); link still labeled via `aria-label` + `title`. Balanced anchors remove an invalid-DOM edge. (Note, not changed here: `area-hidden` is a typo for `aria-hidden` — future cleanup.)

## Backward Compatibility
Adding the class is additive. ⚠️ Intended consequence: author CSS/JS that previously targeted `.eael-fg-video-play-icon` and silently no-op'd will now apply (resolves the customer case). Undocumented `img[alt="eael-fg-video-play-icon"]` selectors stop matching (never a supported hook). The `:4262` change only alters the card+video branch (previously invalid markup); all other branches byte-identical.

## Risk Assessment
Low. Markup-only, no JS/CSS/settings. Primary risk is an un-enumerated layout combo at `:4262`; mitigated by the matrix and by the proof the new condition equals the opener.

## Rollback
Revert the single commit. Pure render change — no persisted state.

## Release Notes
Fixed: Corrected invalid HTML (unbalanced closing tag) for video items in Card layout. Improved: The gallery video play icon now exposes an `eael-fg-video-play-icon` CSS class. Note: existing custom CSS targeting this class will now apply.

## Reviewer Notes
Chose to recompute the opener condition at `:4262` rather than add a `$close_media_link` flag — stateless, mirrors existing `$close_media_content_wrap` symmetry. Can switch to an explicit boolean if preferred. Merge this before PR3 (both edit this file; non-overlapping lines).
