### PR TITLE
Fix: Filterable Gallery video anchors double-bind Magnific and Elementor lightbox

### DIFF
--- a/includes/Elements/Filterable_Gallery.php
+++ b/includes/Elements/Filterable_Gallery.php
@@ -3929,7 +3929,10 @@ class Filterable_Gallery extends Widget_Base
         $title      = isset( $item['title'] ) ? $item['title'] : '';
         $classes    = "video-popup eael-magnific-link eael-magnific-link-clone active eael-magnific-video-link mfp-iframe playout-" . $item['video_layout'];
         
-        $html .= '<a area-hidden="true"  title="' . esc_attr( wp_strip_all_tags( $title ) ) .'" aria-label="eael-magnific-video-link" href="' . esc_url($video_url) . '" class="' . esc_attr( $classes ) . '" data-id="'. esc_attr( $item['id'] ) .'" data-elementor-open-lightbox="yes">';
+        // EA Magnific Popup is the single owner of video lightbox clicks (bound in
+        // assets JS on .eael-magnific-link.active). Opt the anchor out of Elementor's
+        // global lightbox to prevent both systems binding the same tap.
+        $html .= '<a area-hidden="true"  title="' . esc_attr( wp_strip_all_tags( $title ) ) .'" aria-label="eael-magnific-video-link" href="' . esc_url($video_url) . '" class="' . esc_attr( $classes ) . '" data-id="'. esc_attr( $item['id'] ) .'" data-elementor-open-lightbox="no">';
 
         if( $show_video_popup_bg ) {
             if( 'caption-style-card' === $caption_style ) {


### PR DESCRIPTION
## Executive Summary
Each video anchor is simultaneously claimed by **EA's Magnific Popup** (delegated click on `.eael-magnific-link.active`) and **Elementor's native lightbox** (`data-elementor-open-lightbox="yes"`). Two delegated handlers fire on one tap, producing nondeterministic activation (especially on Android). This establishes **EA Magnific Popup as the single owner** of video clicks by opting the video anchor out of Elementor's lightbox. Highest regression risk of the set — isolated for independent revert.

## Problem Statement
- Anchor hardcodes `data-elementor-open-lightbox="yes"` and Magnific classes `eael-magnific-link … eael-magnific-video-link mfp-iframe` — `Filterable_Gallery.php:3930-3932`.
- EA binds Magnific on the gallery scope — `src/js/view/filterable-gallery.js:209-211`: `delegate: "….eael-magnific-link.active"`.
- Elementor Pro globally binds `[data-elementor-open-lightbox="yes"]`. Both receive the same `click`; ownership is order/preventDefault dependent.

## Root Cause
Two lightbox systems wired to one element. EA's gallery JS is the intended owner (registers the Magnific iframe module with YouTube/Vimeo patterns + vertical/horizontal video chrome), but the render still tags the anchor for Elementor's lightbox.

## Technical Solution
Set the video anchor's `data-elementor-open-lightbox` to **`"no"`** (explicit opt-out is more robust than removing the attribute or relying on the site's global default). Magnific binds on `.eael-magnific-link.active`, unaffected, and becomes the sole handler. No JS change required.

## Detailed File Changes
**`includes/Elements/Filterable_Gallery.php` ~3932** — opt video anchors out of Elementor's lightbox:
```diff
-        $html .= '<a area-hidden="true"  title="' . esc_attr( wp_strip_all_tags( $title ) ) .'" aria-label="eael-magnific-video-link" href="' . esc_url($video_url) . '" class="' . esc_attr( $classes ) . '" data-id="'. esc_attr( $item['id'] ) .'" data-elementor-open-lightbox="yes">';
+        $html .= '<a area-hidden="true"  title="' . esc_attr( wp_strip_all_tags( $title ) ) .'" aria-label="eael-magnific-video-link" href="' . esc_url($video_url) . '" class="' . esc_attr( $classes ) . '" data-id="'. esc_attr( $item['id'] ) .'" data-elementor-open-lightbox="no">';
```
**`src/js/view/filterable-gallery.js`** — no change; Magnific remains sole binder (`:209-211`).

## QA Checklist
Desktop: [ ] Chrome [ ] Firefox [ ] Safari [ ] Edge — click a video tile opens exactly one popup (EA Magnific iframe), not Elementor's; no double-open/flicker; close/Esc works once.
Mobile: [ ] Android Chrome [ ] Samsung Internet [ ] iOS Safari — single Magnific popup.
Widget modes: [ ] Card [ ] Search & Filter (incl. after filter + Load More).
Content: [ ] Video — Magnific iframe opens; vertical (`playout-vertical`) + horizontal render correct chrome. [ ] Image — unchanged (not touched).

## Regression Checklist
[ ] Elementor global lightbox ENABLED — gallery videos open via Magnific only; other Elementor lightbox links still work. [ ] Elementor global lightbox DISABLED — videos still open via Magnific. [ ] Magnific prev/next arrows + vertical-video toggling (`js:126-149`) work. [ ] mfp close button / overlay / Esc each close once. [ ] Mixed image+video gallery — both open correct popup.

## Accessibility Review
`data-elementor-open-lightbox="no"` does not alter accessible name/role; anchor keeps `aria-label` + `title`. Removes a potential double focus-trap (two contending lightboxes). Verify focus returns to the trigger after close.

## Backward Compatibility
Sites relying on Elementor's lightbox for gallery videos now get EA's Magnific popup (visual/control differences expected) — intended single-ownership outcome; flagged in release notes. No settings/classes/hooks removed. Image lightbox path untouched.

## Risk Assessment
High (relative). Changes click ownership for every video item on every site, not just touch. Failure mode: "video popup style/controls changed" or worst case "video doesn't open if Magnific init skipped." Mitigations: EA Magnific init runs on ready and is the documented owner; QA covers global-lightbox on/off. Keep independently revertable — do not squash with PR1/PR2.

## Rollback
Revert the single one-attribute commit to restore `="yes"`. No migration, no asset rebuild.

## Release Notes
Fixed: Filterable Gallery video items no longer bind two lightbox systems at once. Videos now open consistently through Essential Addons' popup. Sites that previously relied on Elementor's lightbox for these videos will now see the Essential Addons video popup.

## Reviewer Notes
Scoped to the video anchor (validated conflict). Non-video media anchors (`:4226`, `:4252`, `:3854`) also carry `data-elementor-open-lightbox` but driven by setting-derived `$is_lightbox`, not hardcoded — lower conflict surface; extend in a follow-up rather than widen this high-risk PR. Rejected alternative: removing the attribute entirely — explicit `="no"` overrides a site's global default deterministically. Confirm min-supported Elementor honors `="no"`.
