### PR TITLE
WPML Media Translation support for media-supported widgets

### DIFF
--- a/includes/Classes/Helper.php
+++ b/includes/Classes/Helper.php
@@ -2085,4 +2085,32 @@ class Helper
 
 		return get_post_status( $template_id ) === 'publish' && get_post_type( $template_id ) === 'elementor_library';
 	}
+
+	/**
+	 * eael_wpml_translate_media
+	 *
+	 * Resolve an Elementor MEDIA control value (image/video) to its
+	 * WPML-translated attachment so the correct media is shown per language.
+	 * Safe to call when WPML / WPML Media Translation is inactive — the
+	 * `wpml_object_id` filter simply returns the original id unchanged.
+	 *
+	 * @param array $media Elementor MEDIA control value (expects 'id' and 'url').
+	 *
+	 * @return array The media array with translated 'id' and 'url' when available.
+	 */
+	public static function eael_wpml_translate_media( $media ) {
+		if ( ! is_array( $media ) || empty( $media['id'] ) ) {
+			return $media;
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$translated_id = apply_filters( 'wpml_object_id', $media['id'], 'attachment', true );
+
+		if ( $translated_id && (int) $translated_id !== (int) $media['id'] ) {
+			$media['id']  = $translated_id;
+			$media['url'] = wp_get_attachment_url( $translated_id );
+		}
+
+		return $media;
+	}
 }

--- a/includes/Elements/Adv_Tabs.php
+++ b/includes/Elements/Adv_Tabs.php
@@ -1387,7 +1387,8 @@ class Adv_Tabs extends Widget_Base
                                     } else {
                                         echo '<i class="' . esc_attr( $tab['eael_adv_tabs_tab_title_icon'] ) . '"></i>';
                                     } ?>
-                                <?php elseif ($tab['eael_adv_tabs_icon_type'] === 'image') : ?>
+                                <?php elseif ($tab['eael_adv_tabs_icon_type'] === 'image') :
+                                    $tab['eael_adv_tabs_tab_title_image'] = Helper::eael_wpml_translate_media( $tab['eael_adv_tabs_tab_title_image'] ); // WPML Media Translation compatibility ?>
                                     <img src="<?php echo esc_url( $tab['eael_adv_tabs_tab_title_image']['url'] ); ?>" alt="<?php echo esc_attr(get_post_meta($tab['eael_adv_tabs_tab_title_image']['id'], '_wp_attachment_image_alt', true)); ?>">
                                 <?php endif; ?>
                             <?php endif; ?>

--- a/includes/Elements/Data_Table.php
+++ b/includes/Elements/Data_Table.php
@@ -1416,6 +1416,7 @@ class Data_Table extends Widget_Base {
 			            	<?php endif; ?>
 							<?php
 								if( $header_title['eael_data_table_header_col_icon_enabled'] == 'true' && $header_title['eael_data_table_header_icon_type'] == 'image' ) :
+									$header_title['eael_data_table_header_col_img'] = Helper::eael_wpml_translate_media( $header_title['eael_data_table_header_col_img'] ); // WPML Media Translation compatibility
 									$this->add_render_attribute('data_table_th_img'.$i, [
 										'src'	=> esc_url( $header_title['eael_data_table_header_col_img']['url'] ),
 										'class'	=> 'eael-data-table-th-img',

--- a/includes/Elements/Feature_List.php
+++ b/includes/Elements/Feature_List.php
@@ -1065,6 +1065,7 @@ class Feature_List extends Widget_Base {
 
 
             if ( $item['eael_feature_list_icon_type'] == 'image' ) {
+            $item['eael_feature_list_img'] = Helper::eael_wpml_translate_media( $item['eael_feature_list_img'] ); // WPML Media Translation compatibility
             $this->add_render_attribute( 'feature_list_image' . $index, [
                 'src'   => esc_url( $item['eael_feature_list_img']['url'] ),
                 'class' => 'eael-feature-list-img',

--- a/includes/Elements/Filterable_Gallery.php
+++ b/includes/Elements/Filterable_Gallery.php
@@ -3769,6 +3769,7 @@ class Filterable_Gallery extends Widget_Base
         $video_gallery_yt_privacy = ! empty( $settings['video_gallery_yt_privacy'] ) && 'yes' === $settings['video_gallery_yt_privacy'] ? 1 : 0;
         
         foreach ($gallery_items as $gallery) {
+            $gallery['eael_fg_gallery_img'] = Helper::eael_wpml_translate_media( $gallery['eael_fg_gallery_img'] ); // WPML Media Translation compatibility
             $gallery_store[$counter]['title']        = Helper::eael_wp_kses($gallery['eael_fg_gallery_item_name']);
             $gallery_store[$counter]['content']      = $this->parse_text_editor( wp_kses( $gallery['eael_fg_gallery_item_content'], Helper::eael_allowed_tags() ) );
             $gallery_store[$counter]['id']           = $gallery['_id'];

--- a/includes/Elements/Image_Accordion.php
+++ b/includes/Elements/Image_Accordion.php
@@ -1059,6 +1059,7 @@ class Image_Accordion extends Widget_Base {
             <?php
 	        $active    = $img_accordion['eael_accordion_is_active'];
 	        $activeCSS = ( $active === 'yes' ? ' flex: 3 1 0%;' : '' );
+	        $img_accordion['eael_accordion_bg'] = Helper::eael_wpml_translate_media( $img_accordion['eael_accordion_bg'] ); // WPML Media Translation compatibility
 	        $this->add_render_attribute(
 		        'eael-image-accordion-item-wrapper-' . $key,
 		        [

--- a/includes/Elements/Info_Box.php
+++ b/includes/Elements/Info_Box.php
@@ -2512,6 +2512,7 @@ class Info_Box extends Widget_Base
         }
 
         $infobox_image = $this->get_settings('eael_infobox_image');
+        $infobox_image = Helper::eael_wpml_translate_media( $infobox_image ); // WPML Media Translation compatibility
         $infobox_image_url = Group_Control_Image_Size::get_attachment_image_src($infobox_image['id'], 'thumbnail', $settings);
         if (empty($infobox_image_url)){
 	        $infobox_image_url = $infobox_image['url'];

--- a/includes/Elements/Login_Register.php
+++ b/includes/Elements/Login_Register.php
@@ -6667,6 +6667,13 @@ class Login_Register extends Widget_Base {
 		$this->page_id_for_popup = get_queried_object_id();
 
 		//handle form illustration
+		// WPML Media Translation compatibility
+		if ( ! empty( $this->ds['lr_form_image'] ) ) {
+			$this->ds['lr_form_image'] = HelperCLass::eael_wpml_translate_media( $this->ds['lr_form_image'] );
+		}
+		if ( ! empty( $this->ds['lr_form_logo'] ) ) {
+			$this->ds['lr_form_logo'] = HelperCLass::eael_wpml_translate_media( $this->ds['lr_form_logo'] );
+		}
 		$form_image_id               = ! empty( $this->ds['lr_form_image']['id'] ) ? $this->ds['lr_form_image']['id'] : '';
 		$this->form_illustration_pos = ! empty( $this->ds['lr_form_image_position'] ) ? $this->ds['lr_form_image_position'] : 'left';
 		$this->form_illustration_url = Group_Control_Image_Size::get_attachment_image_src( $form_image_id, 'lr_form_image', $this->ds );

--- a/includes/Elements/Sticky_Video.php
+++ b/includes/Elements/Sticky_Video.php
@@ -749,6 +749,9 @@ class Sticky_Video extends Widget_Base
     protected function render()
     {
         $settings = $this->get_settings_for_display();
+        // WPML Media Translation compatibility
+        $settings['eaelsv_overlay_image'] = Helper::eael_wpml_translate_media( $settings['eaelsv_overlay_image'] );
+        $settings['eaelsv_hosted_url']    = Helper::eael_wpml_translate_media( $settings['eaelsv_hosted_url'] );
         $iconNew = $settings['eaelsv_icon_new'];
         $sticky = isset( $settings['eaelsv_is_sticky'] ) ? $settings['eaelsv_is_sticky'] : 'yes';
         $autoplay = ($settings['eaelsv_autopaly'] == 'yes') ? $settings['eaelsv_autopaly'] : 'no';

--- a/includes/Elements/Team_Member.php
+++ b/includes/Elements/Team_Member.php
@@ -1031,6 +1031,7 @@ class Team_Member extends Widget_Base {
 
         $settings = $this->get_settings_for_display();
 		$team_member_image = $settings['eael_team_member_image'] ?? '';
+		$team_member_image = HelperClass::eael_wpml_translate_media( $team_member_image ); // WPML Media Translation compatibility
 		$image_url = $team_member_image['url'] ?? '';
 		$alt_text = $settings['eael_team_member_name'] ?? '';
 

--- a/includes/Elements/Testimonial.php
+++ b/includes/Elements/Testimonial.php
@@ -901,6 +901,7 @@ class Testimonial extends Widget_Base {
 
 	protected function render_testimonial_image() {
 		$settings = $this->get_settings();
+		$settings['image'] = HelperClass::eael_wpml_translate_media( $settings['image'] ); // WPML Media Translation compatibility
 		$image = Group_Control_Image_Size::get_attachment_image_html( $settings );
 		if( ! empty($image) && ! empty($settings['eael_testimonial_enable_avatar']) ) {
 			ob_start();

--- a/includes/Elements/Woo_Product_Gallery.php
+++ b/includes/Elements/Woo_Product_Gallery.php
@@ -3284,6 +3284,7 @@ class Woo_Product_Gallery extends Widget_Base {
 				$all_taxonomy = 'product_tag';
 			}
 
+			$settings['eael_all_tab_thumb'] = HelperClass::eael_wpml_translate_media( $settings['eael_all_tab_thumb'] ); // WPML Media Translation compatibility
 			if ( $show_cat_thumb && !empty($settings['eael_all_tab_thumb']['url'])) {
 				$show_all_cat_thumb = '<img src="' . esc_url( $settings['eael_all_tab_thumb']['url'] ) . '" />';
 			} else {

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -19,6 +19,7 @@
             <fields-in-item items_of="eael_adv_tabs_tab">
                 <field type="Advance Tab: Title" editor_type="LINE">eael_adv_tabs_tab_title</field>
                 <field type="Advance Tab: Content" editor_type="VISUAL">eael_adv_tabs_tab_content</field>
+                <field type="Advance Tab: Title Image" key_of="eael_adv_tabs_tab_title_image" editor_type="MEDIA">id</field>
             </fields-in-item>
             <fields>
                 <field type="Wrapper Link" key_of="eael_wrapper_link" editor_type="LINE">url</field>
@@ -56,6 +57,7 @@
             </conditions>
             <fields-in-item items_of="eael_data_table_header_cols_data">
                 <field type="Data Table: Header" editor_type="LINE">eael_data_table_header_col</field>
+                <field type="Data Table: Header Image" key_of="eael_data_table_header_col_img" editor_type="MEDIA">id</field>
             </fields-in-item>
             <fields-in-item items_of="eael_data_table_content_rows">
                 <field type="Data Table: Cell Text" editor_type="AREA">eael_data_table_content_row_title</field>
@@ -115,6 +117,7 @@
                 <field type="Filterable Gallery: Item Content" editor_type="VISUAL">eael_fg_gallery_item_content</field>
                 <field type="Filterable Gallery: Item Link" key_of="eael_fg_gallery_img_link" editor_type="LINE">url</field>
                 <field type="Filterable Gallery: Item Video Link" editor_type="LINK">eael_fg_gallery_item_video_link</field>
+                <field type="Filterable Gallery: Item Image" key_of="eael_fg_gallery_img" editor_type="MEDIA">id</field>
             </fields-in-item>
         </widget>
         <widget name="eael-image-accordion">
@@ -125,6 +128,7 @@
                 <field type="Image Accordion: Title" editor_type="LINE">eael_accordion_tittle</field>
                 <field type="Image Accordion: Content" editor_type="VISUAL">eael_accordion_content</field>
                 <field type="Image Accordion: Link" key_of="eael_accordion_title_link" editor_type="LINE">url</field>
+                <field type="Image Accordion: Image" key_of="eael_accordion_bg" editor_type="MEDIA">id</field>
             </fields-in-item>
             <fields>
                 <field type="Wrapper Link" key_of="eael_wrapper_link" editor_type="LINE">url</field>
@@ -157,6 +161,7 @@
                 <field type="Info Box: Sub Title Text" editor_type="LINE">eael_infobox_number</field>
                 <field type="Info Box: Button Link" key_of="infobox_button_link_url" editor_type="LINE">url</field>
                 <field type="Info Box: Link" key_of="eael_show_infobox_clickable_link" editor_type="LINE">url</field>
+                <field type="Info Box: Image" key_of="eael_infobox_image" editor_type="MEDIA">id</field>
                 <field type="Wrapper Link" key_of="eael_wrapper_link" editor_type="LINE">url</field>
             </fields>
         </widget>
@@ -233,6 +238,7 @@
                 <field type="Team Member: Name" editor_type="LINE">eael_team_member_name</field>
                 <field type="Team Member: Title" editor_type="LINE">eael_team_member_job_title</field>
                 <field type="Team Member: Description" editor_type="AREA">eael_team_member_description</field>
+                <field type="Team Member: Image" key_of="eael_team_member_image" editor_type="MEDIA">id</field>
                 <field type="Wrapper Link" key_of="eael_wrapper_link" editor_type="LINE">url</field>
             </fields>
             <fields-in-item items_of="eael_team_member_social_profile_links">
@@ -247,6 +253,7 @@
                 <field type="Testimonial: User Name" editor_type="LINE">eael_testimonial_name</field>
                 <field type="Testimonial: Company Name" editor_type="LINE">eael_testimonial_company_title</field>
                 <field type="Testimonial: Description" editor_type="VISUAL">eael_testimonial_description</field>
+                <field type="Testimonial: Avatar" key_of="image" editor_type="MEDIA">id</field>
                 <field type="Wrapper Link" key_of="eael_wrapper_link" editor_type="LINE">url</field>
             </fields>
         </widget>
@@ -271,6 +278,7 @@
                 <field type="Feature List: Title" editor_type="LINE">eael_feature_list_title</field>
                 <field type="Feature List: Content" editor_type="AREA">eael_feature_list_content</field>
                 <field type="Feature List: Link" key_of="eael_feature_list_link" editor_type="LINE">url</field>
+                <field type="Feature List: Image" key_of="eael_feature_list_img" editor_type="MEDIA">id</field>
             </fields-in-item>
             <fields>
                 <field type="Wrapper Link" key_of="eael_wrapper_link" editor_type="LINE">url</field>
@@ -449,6 +457,8 @@
                 <field type="Login | Register Form: Redirect URL" editor_type="LINK">redirect_url>url</field>
                 <field type="Login | Register Form: Register Link" editor_type="LINK">custom_register_url>url</field>
                 <field type="Login | Register Form: Sign in Link Text" editor_type="AREA">login_link_text</field>
+                <field type="Login | Register Form: Form Image" key_of="lr_form_image" editor_type="MEDIA">id</field>
+                <field type="Login | Register Form: Form Logo" key_of="lr_form_logo" editor_type="MEDIA">id</field>
                 <field type="Wrapper Link" key_of="eael_wrapper_link" editor_type="LINE">url</field>
             </fields>
             <fields-in-item items_of="register_fields">
@@ -564,7 +574,17 @@
                 <field type="Woo Product Gallery: Sale Text" editor_type="LINE">eael_product_gallery_sale_text</field>
                 <field type="Woo Product Gallery: Stock Out Text" editor_type="LINE">eael_product_gallery_stockout_text</field>
                 <field type="Woo Product Gallery: Label Text" editor_type="LINE">show_load_more_text</field>
+                <field type="Woo Product Gallery: All Tab Thumbnail" key_of="eael_all_tab_thumb" editor_type="MEDIA">id</field>
                 <field type="Wrapper Link" key_of="eael_wrapper_link" editor_type="LINE">url</field>
+            </fields>
+        </widget>
+        <widget name="eael-sticky-video">
+            <conditions>
+                <condition key="widgetType">eael-sticky-video</condition>
+            </conditions>
+            <fields>
+                <field type="Sticky Video: Overlay Image" key_of="eaelsv_overlay_image" editor_type="MEDIA">id</field>
+                <field type="Sticky Video: Self Hosted Video" key_of="eaelsv_hosted_url" editor_type="MEDIA">id</field>
             </fields>
         </widget>
         <widget name="icon-box">


### PR DESCRIPTION
## Summary

Extends WPML **Media Translation** support to the media-supported widgets that were missing it, mirroring the existing Tooltip / Flip Box approach (and the recent Advanced Accordion media fix in Pro).

For each widget, two things are done:
1. The media control is registered in `wpml-config.xml` as `editor_type="MEDIA"` pointing to `id` (so WPML's Media Translation can map the attachment per language).
2. At render time the stored attachment is resolved to its translated counterpart, so the correct per-language media is displayed.

A shared helper `Helper::eael_wpml_translate_media()` (in `includes/Classes/Helper.php`) keeps the render-side resolution DRY. It is a **safe no-op** when WPML / WPML Media Translation is inactive — the `wpml_object_id` filter returns the original id unchanged.

## Widgets covered (Lite)

| Widget | Media control(s) |
|---|---|
| Info Box | `eael_infobox_image` |
| Team Member | `eael_team_member_image` |
| Testimonial | `image` (avatar) |
| Advanced Tabs | `eael_adv_tabs_tab_title_image` |
| Data Table | `eael_data_table_header_col_img` |
| Feature List | `eael_feature_list_img` |
| Filterable Gallery | `eael_fg_gallery_img` |
| Image Accordion | `eael_accordion_bg` (per-item image) |
| Sticky Video | `eaelsv_overlay_image`, `eaelsv_hosted_url` |
| Login \| Register | `lr_form_image`, `lr_form_logo` |
| Woo Product Gallery | `eael_all_tab_thumb` |

Already supported (unchanged): **Tooltip**, **Flip Box**.

## Notes / out of scope
- The **Pro** counterpart (Content Timeline, Counter, Divider, Flip Carousel, Google Map, Image Comparison, Image Hotspots, Instagram Feed, Interactive Card/Promo, Lightbox, Logo Carousel, Multicolumn Pricing Table, Price Menu, Sphere Photo Viewer, Stacked Cards, Static Product, Team Member Carousel, Testimonial Slider, Toggle) ships in a paired PR on the Pro repo.
- Fallback/placeholder images (Post Grid `*_fallback_img`) and the Code Snippet file icon are intentionally excluded as low-value edge cases.
- No `src/` changes — no asset rebuild required.

## Testing
- `php -l` clean on all changed PHP files.
- `xmllint` valid on `wpml-config.xml`.
- ⚠️ Not yet verified on a live WPML + Media Translation site — recommend a manual pass (translate a page, confirm each widget swaps to the translated attachment, and confirm no regression when WPML is inactive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)