### PR TITLE
Dynamic Gallery: Media Library source query support (#83126)

### DIFF
--- a/includes/Classes/Helper.php
+++ b/includes/Classes/Helper.php
@@ -266,6 +266,13 @@ class Helper
             $args['meta_query'] = array_filter( apply_filters( 'woocommerce_product_query_meta_query', $args['meta_query'], new \WC_Query() ) );
         }
 
+        // Media Library source: attachments use the 'inherit' post status (not 'publish'),
+        // and a gallery should only render image attachments.
+        if ( 'attachment' === $settings['post_type'] ) {
+            $args['post_status']    = 'inherit';
+            $args['post_mime_type'] = 'image';
+        }
+
 	    // Polylang: pin the query to the language of the page/document the widget is
 	    // on, instead of the ambient (cookie / last-page-load) current language. In
 	    // the editor the ambient language flips on every page load, which made the

--- a/includes/Traits/Ajax_Handler.php
+++ b/includes/Traits/Ajax_Handler.php
@@ -231,6 +231,15 @@ trait Ajax_Handler {
 				$args['post_type']   = $dfg_safe_post_types;
 			}
 
+			// Media Library source (no ACF): filter/Load More queries the Media Library
+			// directly. Constrain to image attachments with the 'inherit' status — never
+			// 'any' — so this nopriv path cannot leak non-public content.
+			if ( 'attachment' === $settings['post_type'] && empty( $args['fetch_acf_image'] ) ) {
+				$args['post_type']      = [ 'attachment' ];
+				$args['post_status']    = $dfg_safe_post_status;
+				$args['post_mime_type'] = 'image';
+			}
+
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 			$exclude_ids = json_decode( html_entity_decode( stripslashes ( $_POST['exclude_ids'] ) ) );
 			$args['post__not_in'] = ( !empty( $_POST['exclude_ids'] ) ) ? array_map( 'intval', array_unique( (array) $exclude_ids ) ) : array();

--- a/includes/Traits/Controls.php
+++ b/includes/Traits/Controls.php
@@ -31,6 +31,13 @@ trait Controls
             $post_types['source_dynamic'] = __('Dynamic', 'essential-addons-for-elementor-lite');
         }
 
+        // Dynamic Gallery can source images directly from the Media Library (attachments).
+        // Adding 'attachment' here also lets the taxonomy loop below expose any media
+        // taxonomies (e.g. eael_media_category) as filter controls for this widget only.
+        if ( 'eael-dynamic-filterable-gallery' === $wb->get_name() ) {
+            $post_types['attachment'] = __( 'Media Library', 'essential-addons-for-elementor-lite' );
+        }
+
         $taxonomies = get_taxonomies([], 'objects');
 
         if ('eael-content-ticker' === $wb->get_name()) {


### PR DESCRIPTION
## Summary

Query-layer support for the Dynamic Gallery **Media Library** source — lets the widget source images from the Media Library (attachments) and filter by media taxonomies. **Gated to the Dynamic Gallery widget only** (no other widget gets a Media source). This is the **Lite half** of the change.

## Lite changes
- **`includes/Traits/Controls.php`** — adds a "Media Library" option to the Source dropdown for `eael-dynamic-filterable-gallery`; the existing taxonomy loop then exposes attachment taxonomies (e.g. `eael_media_category`, or any third-party media taxonomy) as filter controls.
- **`includes/Classes/Helper.php` → `get_query_args()`** — when source is `attachment`, query with `post_status = inherit` and `post_mime_type = image`.
- **`includes/Traits/Ajax_Handler.php`** — filter/Load-More for the Media source, constrained to image attachments with `['publish','inherit']` (never `any`) so the nopriv path stays safe.

## Paired with the Pro PR (must ship together)
The taxonomy registration + attachment image rendering live in Pro: **WPDevelopers/essential-addons-elementor#285**.

## Notes
- Opened from a fork (`amin-abir:83126`). Branched from `dev-pr` for a clean diff.
- `php -l` clean; query semantics verified with seeded media.
- Free plugin works unchanged (the Media source only appears for the Pro Dynamic Gallery widget).

Ref: #83126