### PR TITLE
fix(toc): content auto-detect fallback + TOC link/exclude correctness

### DIFF
--- a/src/js/view/table-of-content.js
+++ b/src/js/view/table-of-content.js
@@ -22,8 +22,8 @@
 					? eaelToc.dataset.titleurl
 					: "false";
 			var excludeArr =
-				typeof eaelToc.dataset.excludeSelector !== "undefined"
-					? eaelToc.dataset.excludeSelector.replace(/^,|,$/g, "")
+				typeof eaelToc.dataset.excludeselector !== "undefined"
+					? eaelToc.dataset.excludeselector.replace(/^,|,$/g, "")
 					: "";
 			var allSupportTag = [];
 			var mainSelector = document.querySelectorAll(selector),
@@ -138,8 +138,7 @@
 					liNode.setAttribute("itemprop", "itemListElement");
 				}
 
-				var Linkid =
-					"#" + i + "-" + eael_build_id(titleUrl, currentHeading.textContent);
+				var Linkid = "#" + currentHeading.id;
 				anchorTag.className = "eael-toc-link";
 				anchorTag.setAttribute("itemprop", "item");
 				anchorTag.setAttribute("href", Linkid);
@@ -323,8 +322,10 @@
 				contentSelectro = ".elementor-inner";
 			} else if ($("#site-content")[0]) {
 				contentSelectro = "#site-content";
-			}else if ($(".site-main")){
+			} else if ($(".site-main")[0]) {
 				contentSelectro = ".site-main";
+			} else {
+				contentSelectro = "body";
 			}
 			return contentSelectro;
 		}


### PR DESCRIPTION
## Summary
Fixes three long-standing correctness bugs in the **Table of Contents** frontend build
(`src/js/view/table-of-content.js`), present through 6.6.9. Happy-path behaviour is unchanged;
each fix removes a latent failure. Surfaced while investigating a "TOC present in source but not
rendering" support case.

## Bugs fixed

**1. `eael_toc_check_content()` — auto-detect never falls back correctly**
`$(".site-main")` is a jQuery object, which is **always truthy** even when it matches nothing. So on
a theme without `.site-content` / `.elementor-inner` / `#site-content`, auto-detect returned
`.site-main` unconditionally (even when absent) and never reached a safe default.
→ Guard with `[0]` and add a final `body` fallback.

**2. TOC anchor href built from the loop index instead of the heading id**
The heading `id` is assigned from `listIndex` in `eael_toc_content()`, but the anchor `href` was
built from the hierarchy loop index `i`. They desync as soon as the id pass skips a heading, so links
point at non-existent ids (clicks scroll nowhere / broken deep links).
→ Build the href from `currentHeading.id`, which always matches the target.

**3. Exclude-By-Selector read with the wrong `dataset` casing**
PHP emits `data-excludeSelector`, which the browser lowercases to `data-excludeselector`. The read
used the camelCase `dataset.excludeSelector` → maps to `data-exclude-selector` → always `undefined`,
so the first-pass exclude was a no-op.
→ Use `dataset.excludeselector` (matching the list-building pass).

### ⚠️ Why #2 and #3 ship together
#3 currently **masks** #2: because the exclude read is dead, that pass never skips headings, so
`listIndex == i` and hrefs happen to match today. Fixing #3 alone would **expose** #2. Landing both
keeps links correct.

## Scope
- **src-only.** Built bundles (`assets/front-end/js/view/table-of-content.js` / `.min.js`) are
  regenerated by the release/trunk webpack build — not hand-edited here.
- No change to the floating / scroll-to-reveal UX or default visibility model.

## Test plan
- [ ] Page with an **Exclude By Selector** matching a heading that appears before others → excluded
      heading absent from the list **and** every remaining TOC link scrolls to the correct heading.
- [ ] Theme without `.site-content`/`.elementor-inner`/`#site-content` and an empty Content Selector
      → TOC still builds (falls back to `body`).
- [ ] Regression: pages with a normal Content Selector behave identically.

## Notes for reviewer
Target branch is `dev-pr` per the contribution policy. Bundles to be rebuilt before merge/release.
