### PR TITLE
fix(toc): resilient frontend build (stop silent empty TOC)

### DIFF
--- a/src/js/view/table-of-content.js
+++ b/src/js/view/table-of-content.js
@@ -1,4 +1,4 @@
-(function ($) {
+function eaelTocMain($) {
 	jQuery(document).ready(function () {
 		/**
 		 * add ID in main content heading tag
@@ -14,7 +14,7 @@
 		function eael_toc_content(selector, supportTag) {
 			var listId = document.getElementById("eael-toc-list");
 			if (selector === null || supportTag === undefined || !listId) {
-				return null;
+				return 0;
 			}
 			var eaelToc = document.getElementById("eael-toc");
 			var titleUrl =
@@ -49,11 +49,25 @@
 
 			var firstChild = $("ul.eael-toc-list > li");
 			if (firstChild.length < 1) {
-				document.getElementById("eael-toc").classList.add("eael-toc-disable");
+				eaelToc.classList.add("eael-toc-disable");
+				// diagnostic breadcrumb for support (invisible to visitors)
+				eaelToc.classList.add("eael-toc-not-found");
+				if (window.console && console.debug) {
+					console.debug(
+						"[EA TOC] No headings matched. selector=%o tags=%o containersMatched=%o headingsInSelector=%o",
+						selector,
+						supportTag,
+						mainSelector.length,
+						allSupportTag.length
+					);
+				}
+			} else {
+				eaelToc.classList.remove("eael-toc-not-found");
 			}
 			firstChild.each(function () {
 				this.classList.add("eael-first-child");
 			});
+			return firstChild.length;
 		}
 
 		/**
@@ -411,11 +425,86 @@
 			);
 		}
 
-		const editMode = (typeof isEditMode !== 'undefined')?isEditMode:false;
-		var intSupportTag = $("#eael-toc").data("eaeltoctag");
-		if (intSupportTag !== "" && !editMode) {
-			eael_toc_content(eael_toc_check_content(), intSupportTag);
+		// Resilient build: run from every reliable trigger and retry for late content
+		// so the list can't silently fail to render (single document.ready was fragile).
+		var eaelTocBuildDone = false;
+		var eaelTocRetries = 0;
+		var eaelTocObserver = null;
+
+		function eaelTocDisconnectObserver() {
+			if (eaelTocObserver) {
+				eaelTocObserver.disconnect();
+				eaelTocObserver = null;
+			}
 		}
+
+		function eaelTocObserveContent(selector) {
+			if (eaelTocObserver || !window.MutationObserver) {
+				return;
+			}
+			var root = document.querySelector(selector) || document.body;
+			if (!root) {
+				return;
+			}
+			eaelTocObserver = new MutationObserver(function () {
+				if (eaelTocBuildDone) {
+					eaelTocDisconnectObserver();
+					return;
+				}
+				window.requestAnimationFrame(runEaelTocBuild);
+			});
+			try {
+				eaelTocObserver.observe(root, { childList: true, subtree: true });
+			} catch (e) {}
+			// safety valve: stop observing after 10s no matter what
+			window.setTimeout(eaelTocDisconnectObserver, 10000);
+		}
+
+		function runEaelTocBuild() {
+			if (eaelTocBuildDone || !document.getElementById("eael-toc")) {
+				return;
+			}
+			var editMode = typeof isEditMode !== "undefined" ? isEditMode : false;
+			var intSupportTag = $("#eael-toc").data("eaeltoctag");
+			if (intSupportTag === "" || intSupportTag === undefined || editMode) {
+				return;
+			}
+			var selector = eael_toc_check_content();
+			var built = eael_toc_content(selector, intSupportTag);
+			// reveal immediately if the page is already scrolled (anchor / bfcache)
+			eaelTocSticky();
+			if (built > 0) {
+				eaelTocBuildDone = true;
+				eaelTocDisconnectObserver();
+				return;
+			}
+			if (eaelTocRetries < 10) {
+				eaelTocRetries++;
+				window.setTimeout(runEaelTocBuild, 300);
+				eaelTocObserveContent(selector);
+			}
+		}
+
+		runEaelTocBuild();
+
+		if (window.elementorFrontend && elementorFrontend.hooks) {
+			elementorFrontend.hooks.addAction(
+				"frontend/element_ready/global",
+				function () {
+					runEaelTocBuild();
+				}
+			);
+		}
+		$(window).on("elementor/frontend/init", function () {
+			runEaelTocBuild();
+		});
+		window.addEventListener("pageshow", function () {
+			if (eaelTocBuildDone) {
+				eaelTocSticky();
+			} else {
+				runEaelTocBuild();
+			}
+		});
 
 		// Function to check the window width and add/remove the class
 		function checkWindowSize() {
@@ -429,4 +518,11 @@
 		window.addEventListener('resize', checkWindowSize);
 		
 	});
-})(jQuery);
+}
+
+(function eaelTocBootstrap() {
+	if (typeof window.jQuery === "undefined") {
+		return window.setTimeout(eaelTocBootstrap, 50);
+	}
+	eaelTocMain(window.jQuery);
+})();

--- a/src/js/view/table-of-content.js
+++ b/src/js/view/table-of-content.js
@@ -22,8 +22,8 @@
 					? eaelToc.dataset.titleurl
 					: "false";
 			var excludeArr =
-				typeof eaelToc.dataset.excludeSelector !== "undefined"
-					? eaelToc.dataset.excludeSelector.replace(/^,|,$/g, "")
+				typeof eaelToc.dataset.excludeselector !== "undefined"
+					? eaelToc.dataset.excludeselector.replace(/^,|,$/g, "")
 					: "";
 			var allSupportTag = [];
 			var mainSelector = document.querySelectorAll(selector),
@@ -138,8 +138,7 @@
 					liNode.setAttribute("itemprop", "itemListElement");
 				}
 
-				var Linkid =
-					"#" + i + "-" + eael_build_id(titleUrl, currentHeading.textContent);
+				var Linkid = "#" + currentHeading.id;
 				anchorTag.className = "eael-toc-link";
 				anchorTag.setAttribute("itemprop", "item");
 				anchorTag.setAttribute("href", Linkid);
@@ -323,8 +322,10 @@
 				contentSelectro = ".elementor-inner";
 			} else if ($("#site-content")[0]) {
 				contentSelectro = "#site-content";
-			}else if ($(".site-main")){
+			} else if ($(".site-main")[0]) {
 				contentSelectro = ".site-main";
+			} else {
+				contentSelectro = "body";
 			}
 			return contentSelectro;
 		}


### PR DESCRIPTION
## Summary
Makes the **Table of Contents** client-side list build resilient so it can't silently fail to render.
The floating TOC ships an empty `<ul>` + `eael-toc-disable` and builds the list in JS; today that build
runs from a **single trigger** (`jQuery(document).ready`) with no fallback, so any perturbation of that
one moment leaves the panel `display:none` forever — the "markup is in the page source but nothing
renders" class of report.

> **Stacked on #828** (TOC correctness fixes). Until #828 merges, this PR's diff also shows that commit.
> **src-only** — bundles (`assets/front-end/js/view/table-of-content.js` / `.min.js`) are regenerated by
> the release/trunk webpack build.

## Changes (happy-path behaviour unchanged)
- **Late-jQuery / Delay-JS guard** — the IIFE becomes a named `eaelTocMain($)` invoked by a small
  bootstrap that waits until `window.jQuery` exists, so a delayed/late jQuery can't abort the script with
  `jQuery is not defined`.
- **Single entry point** `runEaelTocBuild()` (guarded by a `buildDone` flag) reused by every trigger:
  `document.ready`, `frontend/element_ready/global`, `elementor/frontend/init`, and bfcache `pageshow`.
- **Bounded retry (10×300ms) + MutationObserver** on the resolved content container to pick up headings
  injected after load (loops, lazy-load, tabs/accordions); rebuild once then disconnect (10s safety cap).
- **Reveal after build** — `eaelTocSticky()` runs once post-build so anchor-deep-link / bfcache-restored
  (already-scrolled) loads reveal without an extra manual scroll.
- **Diagnosability** — on no-match, add the already-styled `eael-toc-not-found` class and emit one
  `console.debug` with selector/tags/counts. Invisible to visitors.
- `eael_toc_content()` now returns the built item count so the runner can decide whether to retry.

## Non-goals
- No change to the floating / scroll-to-reveal UX or the `display:none`-by-default model (compat).

## Test plan
- [ ] Static headings (happy path): identical result to current behaviour.
- [ ] Late-injected headings (loop/lazy/tab) → list builds via observer/retry.
- [ ] Delayed/late jQuery → build still completes (no `jQuery is not defined`).
- [ ] Anchor deep-link + back/forward (bfcache) → panel reveals without an extra scroll.
- [ ] No `#eael-toc` on the page → no errors.

## Notes for reviewer
Target `dev-pr` per policy. Please rebuild bundles before merge/release. Automated jsdom coverage for
these scenarios is available and can be added under `tests/` if desired.
