### PR TITLE
83254 | Fix: MultivendorX 5.0 compatibility — Woo product widgets not filtered by seller store

### DIFF
--- a/includes/Classes/Helper.php
+++ b/includes/Classes/Helper.php
@@ -176,6 +176,54 @@ class Helper
         return $settings;
     }
 
+    /**
+     * Filter product query args by the current MultiVendorX (5.0+) store.
+     *
+     * MultiVendorX 5.0 replaced the legacy vendor taxonomy archive with a virtual
+     * store page and links products to stores via the `multivendorx_store_id`
+     * post meta. When a product widget renders on a store page, limit the query
+     * to that store's products so each seller's page shows only their items.
+     *
+     * @since 6.7.0
+     * @param array $args WP_Query arguments.
+     * @return array
+     */
+    public static function eael_multivendorx_store_query_args( $args ) {
+        if ( ! function_exists( 'MultiVendorX' ) || ! class_exists( '\MultiVendorX\Store\Store' ) ) {
+            return $args;
+        }
+
+        $store_query_var = 'store';
+        if ( is_callable( [ MultiVendorX()->setting, 'get_setting' ] ) ) {
+            $store_query_var = MultiVendorX()->setting->get_setting( 'store_url', 'store' ) ?: 'store';
+        }
+
+        $store_slug = get_query_var( $store_query_var );
+        if ( empty( $store_slug ) || ! is_string( $store_slug ) ) {
+            return $args;
+        }
+
+        $store = \MultiVendorX\Store\Store::get_store( $store_slug, 'slug' );
+        if ( empty( $store ) || ! $store->get_id() ) {
+            return $args;
+        }
+
+        $store_id_meta_key = defined( '\MultiVendorX\Utill::POST_META_SETTINGS' ) && ! empty( \MultiVendorX\Utill::POST_META_SETTINGS['store_id'] )
+            ? \MultiVendorX\Utill::POST_META_SETTINGS['store_id']
+            : 'multivendorx_store_id';
+
+        if ( ! isset( $args['meta_query'] ) || ! is_array( $args['meta_query'] ) ) {
+            $args['meta_query'] = [ 'relation' => 'AND' ];
+        }
+
+        $args['meta_query'][] = [
+            'key'   => $store_id_meta_key,
+            'value' => $store->get_id(),
+        ];
+
+        return apply_filters( 'eael/multivendorx/store_query_args', $args, $store );
+    }
+
     public static function get_query_args($settings = [], $post_type = 'post')
     {
 	    $settings = wp_parse_args( $settings, [

--- a/includes/Elements/Product_Grid.php
+++ b/includes/Elements/Product_Grid.php
@@ -4112,6 +4112,8 @@ class Product_Grid extends Widget_Base
             );
         }
 
+        $args = HelperClass::eael_multivendorx_store_query_args( $args );
+
         return $args;
     }
 

--- a/includes/Elements/Woo_Product_Carousel.php
+++ b/includes/Elements/Woo_Product_Carousel.php
@@ -4073,6 +4073,8 @@ class Woo_Product_Carousel extends Widget_Base {
 		    $tax_query_count++;
 	    }
 
+	    $args = HelperClass::eael_multivendorx_store_query_args( $args );
+
 	    return $args;
     }
 

--- a/includes/Elements/Woo_Product_List.php
+++ b/includes/Elements/Woo_Product_List.php
@@ -4029,6 +4029,8 @@ class Woo_Product_List extends Widget_Base
                 break;
         }
 
+        $args = ClassesHelper::eael_multivendorx_store_query_args( $args );
+
         return $args;
     }
 


### PR DESCRIPTION
**Task:** https://projects.startise.com/wp-admin/admin.php?page=fluent-boards#/boards/30/tasks/83254-Bug-Fix-%7C-MultivendorX-Compati

## Problem
A client marketplace (built with EA + MultivendorX) broke after updating MultivendorX to 5.0: seller/store pages no longer show the seller's products. EA product widgets on a store page list **every product in the marketplace** (or none in archive mode) instead of the store's own items.

## Root cause
MultiVendorX 5.0.0 (2026-04-17) is a ground-up rewrite:
- 4.x: store page was a `dc_vendor_shop` **product-taxonomy archive**; products linked by `post_author` + vendor term. EA's archive detection (`is_product_taxonomy()`) matched and widgets inherited the vendor-filtered query.
- 5.0: stores live in **custom tables** (`wp_multivendorx_stores`), the store page is a **virtual page** (rewrite `^store/([^/]+)` → query var `store`), and products link to stores only via the **`multivendorx_store_id` post meta**. No taxonomy, no author linkage — EA queries have nothing to inherit, so nothing is filtered.

All legacy `MVX_*` classes/hooks were removed in 5.0 and its deprecated-hooks layer ships empty, so no back-compat exists on their side.

## Fix
New `Helper::eael_multivendorx_store_query_args( $args )`:
- No-op unless MultiVendorX 5+ is active (`class_exists( '\MultiVendorX\Store\Store' )`) **and** the current request is a store page (query var from the `store_url` setting resolves to an existing store).
- Otherwise appends `meta_query [ key => multivendorx_store_id, value => store id ]` (meta key read from `Utill::POST_META_SETTINGS` with a hardcoded fallback).
- Result filterable via `eael/multivendorx/store_query_args`.

Applied at the end of the query builders of **Product Grid**, **Woo Product List**, **Woo Product Carousel**. Load-more/pagination inherits the filter because the injected `meta_query` travels with the serialized widget args. MultivendorX 4.x sites are untouched (class guard fails → no-op).

## Verification (Docker sandbox: WP + WC + Elementor + EA 6.6.9 + MultiVendorX 5.0.9)
Setup: store `zee-art-store` (custom-table store, 3 products with `multivendorx_store_id`), 1 decoy product from another vendor, Elementor store template (`multivendorx-store` document) containing EA Product Grid.

| Check | Before | After |
|---|---|---|
| Store page: own products (3) | shown | shown |
| Store page: other vendor's product | **shown (leak)** | not shown |
| Normal page, EA grid: all products incl. both vendors | shown | shown |
| `php -l` all touched files | — | clean |
| New PHP errors in debug.log after page loads | — | none |

## Affected versions
Any EA version + MultivendorX ≥ 5.0.0 (5.0.0 released 2026-04-17; current 5.0.9). Fix is additive: 54 insertions, 0 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)