### PR TITLE
Business Reviews: rating decimal control + hide reviews without text (#83770)

### DIFF
--- a/includes/Elements/Business_Reviews.php
+++ b/includes/Elements/Business_Reviews.php
@@ -697,6 +697,38 @@ class Business_Reviews extends Widget_Base {
 			]
 		);
 
+		$this->add_control(
+			'eael_business_reviews_rating_round',
+			[
+				'label'        => __( 'Round Rating', 'essential-addons-for-elementor-lite' ),
+				'description'  => __( 'Round the business rating value shown in the header (e.g. 4.8000001 becomes 4.8).', 'essential-addons-for-elementor-lite' ),
+				'type'         => Controls_Manager::SWITCHER,
+				'label_on'     => __( 'On', 'essential-addons-for-elementor-lite' ),
+				'label_off'    => __( 'Off', 'essential-addons-for-elementor-lite' ),
+				'return_value' => 'yes',
+				'default'      => '',
+				'condition'    => [
+					'eael_business_reviews_business_rating' => 'yes',
+				],
+			]
+		);
+
+		$this->add_control(
+			'eael_business_reviews_rating_decimals',
+			[
+				'label'     => __( 'Decimal Places', 'essential-addons-for-elementor-lite' ),
+				'type'      => Controls_Manager::NUMBER,
+				'default'   => 1,
+				'min'       => 0,
+				'max'       => 2,
+				'step'      => 1,
+				'condition' => [
+					'eael_business_reviews_business_rating' => 'yes',
+					'eael_business_reviews_rating_round'    => 'yes',
+				],
+			]
+		);
+
 		$this->add_control( 'eael_business_reviews_google_reviews_label', [
 			'label'       => esc_html__( 'Custom Text', 'essential-addons-for-elementor-lite' ),
 			'type'        => Controls_Manager::TEXT,
@@ -864,6 +896,19 @@ class Business_Reviews extends Widget_Base {
 			'eael_business_reviews_review_4_star_hide',
 			[
 				'label'        => __( 'Hide 4 Star Reviews', 'essential-addons-for-elementor-lite' ),
+				'type'         => Controls_Manager::SWITCHER,
+				'label_on'     => __( 'Yes', 'essential-addons-for-elementor-lite' ),
+				'label_off'    => __( 'No', 'essential-addons-for-elementor-lite' ),
+				'return_value' => 'yes',
+				'default'      => '',
+			]
+		);
+
+		$this->add_control(
+			'eael_business_reviews_review_hide_no_text',
+			[
+				'label'        => __( 'Hide Reviews Without Text', 'essential-addons-for-elementor-lite' ),
+				'description'  => __( 'Only show reviews that have a written comment; hide ratings-only reviews.', 'essential-addons-for-elementor-lite' ),
 				'type'         => Controls_Manager::SWITCHER,
 				'label_on'     => __( 'Yes', 'essential-addons-for-elementor-lite' ),
 				'label_off'    => __( 'No', 'essential-addons-for-elementor-lite' ),
@@ -2689,6 +2734,8 @@ class Business_Reviews extends Widget_Base {
 		$business_reviews['business_logo']     				= ! empty( $settings['eael_business_reviews_business_logo'] ) && 'yes' === $settings['eael_business_reviews_business_logo'] ? 1 : 0;
 		$business_reviews['business_name']     				= ! empty( $settings['eael_business_reviews_business_name'] ) && 'yes' === $settings['eael_business_reviews_business_name'] ? 1 : 0;
 		$business_reviews['business_rating']   				= ! empty( $settings['eael_business_reviews_business_rating'] ) && 'yes' === $settings['eael_business_reviews_business_rating'] ? 1 : 0;
+		$business_reviews['rating_round']      				= ! empty( $settings['eael_business_reviews_rating_round'] ) && 'yes' === $settings['eael_business_reviews_rating_round'] ? 1 : 0;
+		$business_reviews['rating_decimals']   				= isset( $settings['eael_business_reviews_rating_decimals'] ) && '' !== $settings['eael_business_reviews_rating_decimals'] ? absint( $settings['eael_business_reviews_rating_decimals'] ) : 1;
 		$business_reviews['business_address']  				= ! empty( $settings['eael_business_reviews_business_address'] ) && 'yes' === $settings['eael_business_reviews_business_address'] ? 1 : 0;
 		$business_reviews['reviewer_photo']    				= ! empty( $settings['eael_business_reviews_reviewer_photo'] ) && 'yes' === $settings['eael_business_reviews_reviewer_photo'] ? 1 : 0;
 		$business_reviews['reviewer_name']     				= ! empty( $settings['eael_business_reviews_reviewer_name'] ) && 'yes' === $settings['eael_business_reviews_reviewer_name'] ? 1 : 0;
@@ -2700,6 +2747,7 @@ class Business_Reviews extends Widget_Base {
 		$business_reviews['review_2_star']     				= empty( $settings['eael_business_reviews_review_2_star_hide'] ) ? 1 : 0;
 		$business_reviews['review_3_star']     				= empty( $settings['eael_business_reviews_review_3_star_hide'] ) ? 1 : 0;
 		$business_reviews['review_4_star']     				= empty( $settings['eael_business_reviews_review_4_star_hide'] ) ? 1 : 0;
+		$business_reviews['review_hide_no_text']			= ! empty( $settings['eael_business_reviews_review_hide_no_text'] ) && 'yes' === $settings['eael_business_reviews_review_hide_no_text'] ? 1 : 0;
 		
 		// Set max reviews count (with backward compatibility)
 		if ( 'google-reviews' === $business_reviews['source'] ) {
@@ -3164,7 +3212,12 @@ class Business_Reviews extends Widget_Base {
 
 							<?php if ( $business_reviews['business_rating'] ): ?>
                                 <div class="eael-google-reviews-business-rating">
-                                    <p><?php echo esc_html( $google_reviews_data['rating'] ); ?></p>
+                                    <p><?php
+										$eael_display_rating = ( ! empty( $business_reviews['rating_round'] ) && is_numeric( $google_reviews_data['rating'] ) )
+											? round( (float) $google_reviews_data['rating'], (int) $business_reviews['rating_decimals'] )
+											: $google_reviews_data['rating'];
+										echo esc_html( $eael_display_rating );
+									?></p>
                                     <p><?php $this->print_business_reviews_ratings( $google_reviews_data['rating'] ); ?></p>
                                     <p><a href="<?php echo esc_url( $google_reviews_data['url'] ); ?>" <?php if ( ! $business_reviews['accessibility_link_in_same_tab'] ) :  ?> target="_blank"  <?php endif; ?> ><?php echo esc_html( number_format( $google_reviews_data['user_ratings_total'] ) . ' ' . $business_reviews['google_reviews_label'] ); ?></a></p>
                                 </div>
@@ -3206,6 +3259,10 @@ class Business_Reviews extends Widget_Base {
 									$should_hide_review = true;
 								}
 								if( ! $business_reviews['review_4_star'] && $single_review_data['rating'] === 4 ){
+									$should_hide_review = true;
+								}
+
+								if( $business_reviews['review_hide_no_text'] && '' === trim( wp_strip_all_tags( (string) $single_review_data['text'] ) ) ){
 									$should_hide_review = true;
 								}
 
@@ -3461,7 +3518,12 @@ class Business_Reviews extends Widget_Base {
 
 							<?php if ( $business_reviews['business_rating'] ): ?>
                                 <div class="eael-google-reviews-business-rating">
-                                    <p><?php echo esc_html( $google_reviews_data['rating'] ); ?></p>
+                                    <p><?php
+										$eael_display_rating = ( ! empty( $business_reviews['rating_round'] ) && is_numeric( $google_reviews_data['rating'] ) )
+											? round( (float) $google_reviews_data['rating'], (int) $business_reviews['rating_decimals'] )
+											: $google_reviews_data['rating'];
+										echo esc_html( $eael_display_rating );
+									?></p>
                                     <p><?php $this->print_business_reviews_ratings( $google_reviews_data['rating'] ); ?></p>
                                     <p><a href="<?php echo esc_url( $google_reviews_data['url'] ); ?>" <?php if( ! $business_reviews['accessibility_link_in_same_tab'] ) : ?> target="_blank"  <?php endif; ?> ><?php echo esc_html( number_format( $google_reviews_data['user_ratings_total'] ) . ' ' . $business_reviews['google_reviews_label'] ); ?></a></p>
                                 </div>
@@ -3503,6 +3565,10 @@ class Business_Reviews extends Widget_Base {
 									$should_hide_review = true;
 								}
 								if( ! $business_reviews['review_4_star'] && $single_review_data['rating'] === 4 ){
+									$should_hide_review = true;
+								}
+
+								if( $business_reviews['review_hide_no_text'] && '' === trim( wp_strip_all_tags( (string) $single_review_data['text'] ) ) ){
 									$should_hide_review = true;
 								}
 


### PR DESCRIPTION
## Summary

Adds **two optional Content-tab controls** to the **Business Reviews** widget (Lite). Both default to off, so existing widgets render exactly as before — no visual or behavioural change until a user opts in.

1. **Rating decimal control** — round the business average rating shown in the header (the Google API can return a raw value like `4.8000001907349`).
2. **Hide Reviews Without Text** — filter out ratings-only reviews (no written comment) from the slider/grid.

Card: #83770

---

## Feature 1 — Rating decimal control

The Google Places API returns the business average as a raw float, so the header often shows a long, messy number. Two new controls under the **Business** group let the user round it:

- `Round Rating` (switcher, default **Off**)
- `Decimal Places` (number, default **1**, min 0 / max 2) — shown only when Round Rating is On

```
CONTENT ▸ Business
────────────────────────────
Rating                 [ ● Show ]
Round Rating           [   Off ○ ]   ← NEW (default off)
   └ when On:
Round Rating           [ ● On   ]
Decimal Places         [  1  ▲▼ ]    ← NEW (conditional)
```

**Front-end effect:**

```
Before:   4.8000001907349
After:    4.8            (Round Rating = On, Decimal Places = 1)
```

**Only the printed number is rounded.** The star icons and the LocalBusiness JSON-LD schema keep the **raw** value, so star rendering and rich-results markup are unchanged. Uses `round()` (no forced trailing zeros — a clean `5` stays `5`).

---

## Feature 2 — Hide Reviews Without Text

A new switcher under the **Review** group, sitting with the existing "Hide N-Star" filters:

- `Hide Reviews Without Text` (switcher, default **No**)

```
CONTENT ▸ Review
────────────────────────────
Hide 1 Star Reviews          [ No ○ ]
Hide 2 Star Reviews          [ No ○ ]
Hide 3 Star Reviews          [ No ○ ]
Hide 4 Star Reviews          [ No ○ ]
Hide Reviews Without Text    [ No ○ ]   ← NEW (default off)
```

When enabled, reviews with no written comment are dropped from the display; text reviews remain.

```
Before:   [★★★★★ "Great service, highly recommend!"]
          [★★★★☆  (no comment)                     ]   ← hidden when On
          [★★★★★ "Fast and friendly."              ]
After:    [★★★★★ "Great service, highly recommend!"]
          [★★★★★ "Fast and friendly."              ]
```

It's implemented inside the existing `$should_hide_review` block, so — like the star filters — hidden reviews don't consume the "Reviews to Show" budget.

---

## Implementation

All changes in `includes/Elements/Business_Reviews.php` (PHP-only — **no asset rebuild required**):

- **Controls** (`register_controls`): `eael_business_reviews_rating_round`, `eael_business_reviews_rating_decimals` (conditioned on the business Rating toggle) and `eael_business_reviews_review_hide_no_text`.
- **Settings map** (`get_business_reviews_settings`): extracts `rating_round`, `rating_decimals` (via `absint`), `review_hide_no_text`.
- **Render** — both the **slider** and **grid** layouts:
  - Rating: rounds the echoed value only, guarded by `is_numeric()`; the raw value is still passed to `print_business_reviews_ratings()` (stars) and to the schema builder.
  - Reviews loop: `if ( $review_hide_no_text && '' === trim( wp_strip_all_tags( (string) $text ) ) ) { skip; }`.

### Pro note
Pro's `Business_Reviews_Extender::render_business_profile_reviews()` delegates to these same Lite print functions, so **both features automatically apply to the Pro Google Business Profile source too** — no Pro-side change needed. The review `text` field is reliably populated for all sources (old Places API native, new Places API mapping, and Pro's Business Profile `comment` mapping).

---

## Backward compatibility
- Both controls default to off/No → **existing widgets are unaffected**.
- No schema change, no control removed/renamed, no asset/JS change.
- Text domain: `essential-addons-for-elementor-lite`.

## Testing
- `php -l` clean.
- Rendered live in the Elementor editor and frontend (server-rendered), both slider and grid layouts. Requires a Google Places API key configured in the widget to pull live reviews.
- Edge cases handled: empty rating (`''`) guarded with `is_numeric`; whitespace-only comment handled via `trim( wp_strip_all_tags() )`.
