### PR TITLE
fix: Woo Product Gallery infinity scroll stops after first page on archives

### DIFF
--- a/includes/Elements/Woo_Product_Gallery.php
+++ b/includes/Elements/Woo_Product_Gallery.php
@@ -2907,9 +2907,34 @@ class Woo_Product_Gallery extends Widget_Base {
 					if( $settings['post_type'] === 'archive' && is_archive() && $is_product_archive ){
                         global $wp_query;
                         $query = $wp_query;
-                        $args  = $wp_query->query_vars;
                         $found_posts = $query->found_posts;
                         $max_page = $query->max_num_pages;
+
+                        // Build a clean query for the Load More / Infinity Scroll requests
+                        // instead of serializing the whole main-query query_vars. The raw
+                        // query_vars carry WP defaults (empty post_type, empty menu_order,
+                        // etc.) that make the re-run WP_Query in the AJAX handler return
+                        // zero results on some setups (e.g. products with a custom menu
+                        // order), so pagination stops after the first page.
+                        $args = [
+                            'post_type'      => 'product',
+                            'post_status'    => 'publish',
+                            'posts_per_page' => (int) ( $wp_query->get( 'posts_per_page' ) ?: ( $settings['eael_product_gallery_products_count'] ?: 4 ) ),
+                            'orderby'        => $wp_query->get( 'orderby' ) ?: 'menu_order title',
+                            'order'          => $wp_query->get( 'order' ) ?: 'ASC',
+                        ];
+
+                        // Keep the current archive taxonomy term (product category, tag or attribute).
+                        $queried_object = $query->get_queried_object();
+                        if ( $queried_object instanceof \WP_Term ) {
+                            $args['tax_query'] = [
+                                [
+                                    'taxonomy' => $queried_object->taxonomy,
+                                    'field'    => 'term_id',
+                                    'terms'    => $queried_object->term_id,
+                                ],
+                            ];
+                        }
                     } else {
 	                    $query = new \WP_Query( $args );
                     }

--- a/includes/Traits/Ajax_Handler.php
+++ b/includes/Traits/Ajax_Handler.php
@@ -187,6 +187,15 @@ trait Ajax_Handler {
 				unset( $args['offset'] );
 			}
 		}
+		if ( $class === '\Essential_Addons_Elementor\Elements\Woo_Product_Gallery' ) {
+			// Safety net for Product Gallery archive requests: older markup may still
+			// send the raw main-query args with an empty post_type, which makes the
+			// WP_Query below default to the "post" type and return nothing. Force the
+			// product post type so Load More / Infinity Scroll keeps returning products.
+			if ( empty( $args['post_type'] ) ) {
+				$args['post_type'] = 'product';
+			}
+		}
 		if ( $class === '\Essential_Addons_Elementor\Elements\Product_Grid' ) {
 			do_action( 'eael_woo_before_product_loop', $settings['eael_product_grid_style_preset'] );
 		}


### PR DESCRIPTION
##Card: https://projects.startise.com/wp-admin/admin.php?page=fluent-boards#/boards/30/tasks/83799-Bug-Fix-%7C-EA-Woo-Product-Galle

### Problem
On a WooCommerce archive (product category / tag / shop) the **Woo Product Gallery** widget with **Source = Current Archive** and Load More/Infinity Scroll enabled stops loading after the first page. The loader spins, then nothing appends — grids stay capped at the first page (reported live: 16 of 120 products, every category).

### Root cause
In `Woo_Product_Gallery::render()` the archive branch copied the **entire** main-query `\$wp_query->query_vars` into the Load More `data-args`:

```php
$args = $wp_query->query_vars; // 50+ WP default vars, incl. empty post_type & menu_order
```

`Ajax_Handler::ajax_load_more()` then re-runs `new WP_Query( $args )` on that raw dump. Two WP defaults in it break the re-run query:
- `post_type => ''` → WP_Query falls back to the `post` type.
- `menu_order => ''` → on stores whose products have a **custom menu order**, the ordering stack treats it as `menu_order = 0`, matching nothing from page 2 onward.

Result: `have_posts()` is false → `No posts found!` → infinity scroll halts. Isolated var-by-var against the live site; a clean product query paginates all pages correctly (p1–p6 = 16, p7 = 10, p8+ empty). `Woo_Product_Gallery` was also absent from the class special-cases in `ajax_load_more()`, so nothing forced the product post type.

### Fix
1. **`includes/Elements/Woo_Product_Gallery.php`** — archive branch now builds a clean query for the Load More args (`post_type`, `post_status`, `posts_per_page`, `orderby`, `order` + the current archive term via `get_queried_object()`) instead of serializing raw `query_vars`. Page-1 render still uses the real main query.
2. **`includes/Traits/Ajax_Handler.php`** — `ajax_load_more()` safety net: force `post_type = 'product'` for `Woo_Product_Gallery` when it arrives empty (covers already-cached markup).

### Verification
| | Before | After |
|---|---|---|
| Live replay, page 2+ | `No posts found!` (0) | 16/page → all products load, clean end |
| `data-args` post_type | *(empty)* | `product` |
| `data-args` payload | 50+ raw query_vars incl. `menu_order=''` | clean product query + category term |
| Sandbox infinity scroll | n/a | loads all products, no errors, `php -l` clean |

Affected: EA Lite (free). Widget: Woo Product Gallery, archive source + Load More/Infinity Scroll.