### PR TITLE
fix: EA injects large control defaults into every element → HTTP 413 on save

### DIFF
--- a/includes/Extensions/Image_Masking.php
+++ b/includes/Extensions/Image_Masking.php
@@ -178,7 +178,9 @@ class Image_Masking {
                 'ai' => [
 					'active' => false,
 				],
-                'default'     => 'clip-path: polygon(50% 0%, 80% 10%, 100% 35%, 100% 70%, 80% 90%, 50% 100%, 20% 90%, 0% 70%, 0% 35%, 20% 10%);',
+                // Default kept empty so this is not serialized into every element; the starter
+                // shape is applied at render time when custom clip path is enabled but left blank.
+                'default'     => '',
                 'placeholder' => 'clip-path: polygon(50% 0%, 0% 100%, 100% 100%);',
                 'description' => __( 'Enter your custom clip path value. You can use <a href = "https://bennettfeely.com/clippy/" target = "_blank">Clippy</a> to generate your custom clip path.', 'essential-addons-for-elementor-lite' ),
                 'condition'   => array_merge( $condition, [ 'eael_image_masking_enable_custom_clip_path' . $tab => 'yes' ] ),
@@ -563,7 +565,7 @@ class Image_Masking {
 			if( 'clip' === $type ){
                 $clip_path_value = '';
                 if( 'yes' === $settings['eael_image_masking_enable_custom_clip_path'] ){
-                    $clip_path_value = $settings['eael_image_masking_custom_clip_path'];
+                    $clip_path_value = ! empty( $settings['eael_image_masking_custom_clip_path'] ) ? $settings['eael_image_masking_custom_clip_path'] : 'clip-path: polygon(50% 0%, 80% 10%, 100% 35%, 100% 70%, 80% 90%, 50% 100%, 20% 90%, 0% 70%, 0% 35%, 20% 10%);';
                     $clip_path_value = str_replace( 'clip-path: ', '', $clip_path_value );
                     $clip_path_value = self::sanitize_css_fragment( $clip_path_value );
                 } else {
@@ -577,7 +579,7 @@ class Image_Masking {
                 if( 'yes' === $settings['eael_image_masking_hover_effect'] ){
                     $hover_clip_path_value = '';
                     if( 'yes' === $settings['eael_image_masking_enable_custom_clip_path_hover'] ){
-                        $hover_clip_path_value = $settings['eael_image_masking_custom_clip_path_hover'];
+                        $hover_clip_path_value = ! empty( $settings['eael_image_masking_custom_clip_path_hover'] ) ? $settings['eael_image_masking_custom_clip_path_hover'] : 'clip-path: polygon(50% 0%, 80% 10%, 100% 35%, 100% 70%, 80% 90%, 50% 100%, 20% 90%, 0% 70%, 0% 35%, 20% 10%);';
                         $hover_clip_path_value = str_replace( 'clip-path: ', '', $hover_clip_path_value );
                         $hover_clip_path_value = self::sanitize_css_fragment( $hover_clip_path_value );
                     } else {

--- a/includes/Extensions/Vertical_Text_Orientation.php
+++ b/includes/Extensions/Vertical_Text_Orientation.php
@@ -309,22 +309,10 @@ class Vertical_Text_Orientation {
 				'label'   => esc_html__( 'Choose Gradient Colors', 'essential-addons-for-elementor-lite' ),
 				'type'    => Controls_Manager::REPEATER,
 				'fields'  => $repeater->get_controls(),
-				'default' => [
-					[
-						'eael_vto_writing_gradient_color' => '#7C62FF',
-                        'eael_vto_writing_gradient_color_location' => [
-                            'unit' => '%',
-                            'size' => 50,
-                        ],
-					],
-					[
-						'eael_vto_writing_gradient_color' => '#FF6464',
-                        'eael_vto_writing_gradient_color_location' => [
-                            'unit' => '%',
-                            'size' => 90,
-                        ],
-					],
-				],
+				// Default kept empty: a non-empty repeater default is serialized (with per-row _id)
+				// into every element and never stripped by Elementor. The starter gradient is applied
+				// at render time via eael_vto_default_gradient_colors() when the feature is enabled.
+				'default' => [],
 				'title_field' => '{{{ eael_vto_writing_gradient_color }}}',
                 'condition' => [
 					'eael_vertical_text_orientation_switch' => 'yes',
@@ -534,11 +522,28 @@ class Vertical_Text_Orientation {
 		$element->end_controls_section();
 	}
 
+	/**
+	 * Starter gradient colours, applied at render time when the user has defined none.
+	 * Kept out of the control default so they are not serialized into every element.
+	 */
+	private function eael_vto_default_gradient_colors() {
+		return [
+			[ 'eael_vto_writing_gradient_color' => '#7C62FF', 'eael_vto_writing_gradient_color_location' => [ 'unit' => '%', 'size' => 50 ] ],
+			[ 'eael_vto_writing_gradient_color' => '#FF6464', 'eael_vto_writing_gradient_color_location' => [ 'unit' => '%', 'size' => 90 ] ],
+		];
+	}
+
 	public function before_render( $element ) {
 		$settings = $element->get_settings_for_display();
-        if ( !empty( $settings['eael_vto_writing_gradient_color_repeater'] ) && is_array( $settings['eael_vto_writing_gradient_color_repeater'] ) ) {
+        $gradient_repeater = $settings['eael_vto_writing_gradient_color_repeater'] ?? [];
+        if ( empty( $gradient_repeater )
+            && 'yes' === ( $settings['eael_vertical_text_orientation_switch'] ?? '' )
+            && 'gradient' === ( $settings['eael_vto_writing_styling_type'] ?? '' ) ) {
+            $gradient_repeater = $this->eael_vto_default_gradient_colors();
+        }
+        if ( !empty( $gradient_repeater ) && is_array( $gradient_repeater ) ) {
             $gradient_colors = [];
-            foreach ( $settings['eael_vto_writing_gradient_color_repeater'] as $value ) {
+            foreach ( $gradient_repeater as $value ) {
                 $gradient_colors[] = [
                     'color' => $value['eael_vto_writing_gradient_color'],
                     'location' => $value['eael_vto_writing_gradient_color_location']['size'] . $value['eael_vto_writing_gradient_color_location']['unit'],


### PR DESCRIPTION
##Card: https://projects.startise.com/wp-admin/admin.php?page=fluent-boards#/boards/30/tasks/83800-Bug-Fix-%7C-Essential-Addons-%7C-E

## Problem
Saving an Elementor page returns **HTTP 413** on hosts with strict POST limits whenever Essential Addons is active, **even on pages with zero EA widgets**. Stored `_elementor_data` balloons (client: 123 KB → 1.12 MB).

## Root cause (Lite portion)
`Image_Masking.php` and `Vertical_Text_Orientation.php` register controls on every common element (widget / section / column / container) with large non-empty `default` values:

- `eael_image_masking_custom_clip_path` (+ `_hover`) — clip-path polygon default
- `eael_vto_writing_gradient_color_repeater` — two-stop gradient repeater default

Elementor cannot strip these on save (repeater rows get a runtime `_id`; the scalar default diverges), so they serialize into `_elementor_data` and every save POST for every element regardless of feature use.

## Fix
Empty each control default; apply the real default at render time — clip-path fallback inline, gradient via `eael_vto_default_gradient_colors()`. No behavior change.

## Verification (sandbox: Lite 6.6.10 + Pro 7.0.1, Elementor 4.1.5)
8 core widgets, 0 EA widgets — stored `_elementor_data` after a real editor save: **~24 KB → 831 bytes, 0 `eael_` keys**. No PHP errors; page renders HTTP 200.

Companion Pro PR: WPDevelopers/essential-addons-elementor#289 (same pattern for Custom Cursor, Extender/Image-Masking-morphing, Conditional Display, Content Protection, Tooltip).