### PR TITLE
Cap a custom-width mega menu panel to the room it has (#898)

### DIFF
--- a/src/css/view/mega-menu.scss
+++ b/src/css/view/mega-menu.scss
@@ -217,7 +217,11 @@
 		top: calc(100% + var(--eael-mm-panel-offset, 0px) + var(--eael-mm-panel-offset-y, 0px));
 		inset-inline-start: var(--eael-mm-panel-inset-start, 0px);
 		width: var(--eael-mm-panel-width, 100%);
-		max-width: none;
+		/* Only the modes that can overrun set this. `viewport` is measured to
+		 * the viewport already and `full` tracks the menu, so both leave it
+		 * unset; `custom` is a fixed pixel width and has the handler measure a
+		 * cap for it. The `item` rule below overrides this outright. */
+		max-width: var(--eael-mm-panel-max-width, none);
 		z-index: var(--eael-mm-panel-z-index, 999);
 		opacity: 0;
 		visibility: hidden;

--- a/src/js/view/mega-menu.js
+++ b/src/js/view/mega-menu.js
@@ -681,6 +681,12 @@ const getMegaMenuHandler = () =>
 			const $item = this.getItemByIndex(index);
 			const container = this.elements.$container[0];
 
+			// Only "custom" sets a cap, and it does so at the end once its inline
+			// offset is known. Clearing here rather than in that branch covers the
+			// modes that return early, so a panel that changes mode in the editor
+			// cannot keep a stale one.
+			panel.style.removeProperty("--eael-mm-panel-max-width");
+
 			if (!container) {
 				return;
 			}
@@ -750,7 +756,32 @@ const getMegaMenuHandler = () =>
 						: itemOffset + itemWidth - panelWidth;
 			}
 
-			panel.style.setProperty("--eael-mm-panel-inset-start", `${start + offsetX}px`);
+			const inset = start + offsetX;
+
+			panel.style.setProperty("--eael-mm-panel-inset-start", `${inset}px`);
+
+			// A fixed pixel width is the one mode that can be wider than the room
+			// it sits in. `full` tracks the menu and `viewport` is measured to the
+			// viewport, while `item` shrinks to fit — but a 620px panel anchored
+			// part way along the bar runs past the right edge and drags a
+			// horizontal scrollbar onto the document (issue #898).
+			//
+			// Measured, not `100vw`: `vw` counts the scrollbar, so capping with it
+			// on a page that already has one leaves the panel a scrollbar's width
+			// too wide — the same reason measureEditingWidth() reads clientWidth.
+			//
+			// `inset-inline-start` is the RIGHT edge in RTL, where the panel grows
+			// leftward, so the room is measured from whichever edge it starts at.
+			if ("custom" === mode) {
+				const rect = container.getBoundingClientRect();
+				const room = this.isRtl()
+					? rect.right - inset
+					: document.documentElement.clientWidth - (rect.left + inset);
+
+				if (room > 0) {
+					panel.style.setProperty("--eael-mm-panel-max-width", `${room}px`);
+				}
+			}
 		}
 
 		/**


### PR DESCRIPTION
Fixes #898.

## What was wrong

A `custom` submenu width is a fixed pixel value — 620px in the SaaS Menu preset — and it was the one width mode with no backstop:

| mode | guard |
|---|---|
| `full` | tracks the menu |
| `viewport` | measured against `clientWidth`, so it cannot overrun by construction |
| `item` | `max-width: min(100vw, 100%)` |
| `custom` | **`max-width: none`** |

Anchored part way along the bar, a 620px panel runs past the right edge: at a 1080px viewport it ended at 1088.5px and the document grew a horizontal scrollbar.

## The fix

The handler measures the room between the panel's own starting edge and the viewport, and caps the panel there via a `--eael-mm-panel-max-width` custom property. It's **inert whenever the panel already fits** — which is why 1100px and up were fine before and are untouched now.

Three things that shaped the implementation:

- **Measured, not `100vw`.** `measureEditingWidth()` in this same file already documents why: `vw` counts the scrollbar, so capping with it on a page that has one leaves the panel a scrollbar's width too wide. A CSS-only `100vw` cap would have narrowed the overflow rather than removed it.
- **RTL.** `inset-inline-start` is the *right* edge under RTL, where the panel grows leftward, so the room is measured from whichever edge the panel actually starts at.
- **The variable is cleared once, before the mode branches.** `full` and `viewport` `return` early, so clearing inside the `custom` branch would let a panel that changes width mode in the editor keep a stale cap.

## Needs a build

Source only. `assets/front-end/` is built from `src/` and is tracked, so this needs `npm run build` to take effect. I couldn't run it here — no `node_modules`, and this machine is on Node 22 against the repo's `^20.20.0` (webpack 4 won't run on 22).

## Heads-up on formatting

`src/js/view/mega-menu.js` and `src/css/view/mega-menu.scss` **already fail** the repo's own prettier config before this change — running it rewrites 178 lines of the JS, mostly re-joining wrapped lines under the current `printWidth: 120`. The committed sources predate that config.

I committed without the hook so this PR stays the fix and nothing else, rather than burying ~20 real lines inside a 178-line reformat. Flagging rather than silently bypassing: a separate formatting pass over these files looks overdue, and lint-staged will reformat them wholesale on whatever touches them next.

`node --check` passes on the JS.